### PR TITLE
More transparent wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ helm_vars/
 └── values.yaml
 ```
 As you can see we can run different PGP or KMS keys per project, globally or per any tree level. Thanks to this we can isolate tree on different CI/CD instances using same GIT repository.
-As we use simple -f option when running helm we can just use secrets.yaml.dec (encrypted file is just secrets.yaml and we point .dec as result of on-the-fly decryption) files with helm-wrapper and all secrets will be decrypted and cleaned on the fly with helm run.
+As we use simple -f option when running helm-wrapper we can just use encrypted secrets.yaml and all this secrets will be decrypted and cleaned on the fly before and after helm run.
 
 ```.sops.yaml``` file example
 ```

--- a/secrets.sh
+++ b/secrets.sh
@@ -249,7 +249,6 @@ clean() {
   chart="$1"
   vars_load "$chart"
   basedir="$(dirname ${templates_dir})"
-  echo "find ${templates_dir} -type f -name *.yaml${DEC_SUFFIX}"
   while read dec_file;
   do
   if [ -f "${dec_file}" ];

--- a/secrets.sh
+++ b/secrets.sh
@@ -248,15 +248,17 @@ clean() {
   sops_config
   chart="$1"
   vars_load "$chart"
-  echo "Decrypted secrets files clean"
+  basedir="$(dirname ${templates_dir})"
+  echo "find ${templates_dir} -type f -name *.yaml${DEC_SUFFIX}"
   while read dec_file;
   do
-  if [ -f "${dec_file}" ]; then
+  if [ -f "${dec_file}" ];
+  then
      rm -v  "${dec_file}"
   else
      echo "Nothing to Clean"
   fi
-  done < <(find "$templates_dir" -type f -name "*.yaml${DEC_SUFFIX}" )
+  done < <(find "${basedir}" -type f -name "*.yaml${DEC_SUFFIX}" )
 }
 
 view_helper() {

--- a/test.sh
+++ b/test.sh
@@ -73,23 +73,32 @@ fi
 
 test_helm_secrets() {
 echo -e "${YELLOW}+++${NOC} ${BLUE}Testing ${secret}${NOC}"
+
 echo -e "${YELLOW}+++${NOC} Encrypt and Test"
 "${HELM_CMD}" secrets enc "${secret}" > /dev/null || exit 1 && \
 test_encryption "${secret}"
+
 echo -e "${YELLOW}+++${NOC} View encrypted Test"
 test_view "${secret}"
+
 echo -e "${YELLOW}+++${NOC} Decrypt"
 "${HELM_CMD}" secrets dec "${secret}" > /dev/null || exit 1 && \
 test_decrypt "${secret}" && \
 cp "${secret}.dec" "${secret}"
+
 echo -e "${YELLOW}+++${NOC} Cleanup Test"
-"${HELM_CMD}" secrets clean "$(dirname ${secret})" > /dev/null || exit 1 && \
-mode="directory"
+"${HELM_CMD}" secrets clean "$(dirname ${secret})" > /dev/null || exit 1
+mode="specified directory"
 test_clean "${secret}" "${mode}" && \
 cp "${secret}" "${secret}.dec" && \
-"${HELM_CMD}" secrets clean "${secret}.dec" > /dev/null || exit 1 && \
+"${HELM_CMD}" secrets clean "${secret}.dec" > /dev/null || exit 1
 mode="specified .dec file"
+test_clean "${secret}" "${mode}" && \
+cp "${secret}" "${secret}.dec" && \
+"${HELM_CMD}" secrets clean "${secret}" > /dev/null || exit 1
+mode="specified encrypted secret file"
 test_clean "${secret}" "${mode}"
+
 echo -e "${YELLOW}+++${NOC} Once again Encrypt and Test"
 "${HELM_CMD}" secrets enc "${secret}" > /dev/null || exit 1 && \
 test_encryption "${secret}"

--- a/test.sh
+++ b/test.sh
@@ -8,6 +8,19 @@ NOC='\033[0m'
 SECRETS_REPO="https://github.com/futuresimple/helm-secrets"
 HELM_CMD="helm"
 
+trap_error() {
+    local status=$?
+    if [ "$status" -ne 0 ]; then
+        echo -e "${RED}General error${NOC}"
+        exit 1
+    else
+        exit 0
+    fi
+    echo -e "${RED}General error${NOC}"
+}
+
+trap "trap_error" EXIT
+
 test_encryption() {
 result=$(cat < "${secret}" | grep -Ec "(40B6FAEC80FD467E3FE9421019F6A67BB1B8DDBE|4434EA5D05F10F59D0DF7399AF1D073646ED4927)")
 if [ "${result}" -eq 2 ] && [ "${secret}" == "./example/helm_vars/secrets.yaml" ];
@@ -61,24 +74,24 @@ fi
 test_helm_secrets() {
 echo -e "${YELLOW}+++${NOC} ${BLUE}Testing ${secret}${NOC}"
 echo -e "${YELLOW}+++${NOC} Encrypt and Test"
-"${HELM_CMD}" secrets enc "${secret}" 2>&1 >/dev/null && \
+"${HELM_CMD}" secrets enc "${secret}" > /dev/null || exit 1 && \
 test_encryption "${secret}"
 echo -e "${YELLOW}+++${NOC} View encrypted Test"
 test_view "${secret}"
 echo -e "${YELLOW}+++${NOC} Decrypt"
-"${HELM_CMD}" secrets dec "${secret}" 2>&1 >/dev/null && \
+"${HELM_CMD}" secrets dec "${secret}" > /dev/null || exit 1 && \
 test_decrypt "${secret}" && \
 cp "${secret}.dec" "${secret}"
 echo -e "${YELLOW}+++${NOC} Cleanup Test"
-"${HELM_CMD}" secrets clean "$(dirname ${secret})" 2>&1 >/dev/null && \
+"${HELM_CMD}" secrets clean "$(dirname ${secret})" > /dev/null || exit 1 && \
 mode="directory"
 test_clean "${secret}" "${mode}" && \
 cp "${secret}" "${secret}.dec" && \
-"${HELM_CMD}" secrets clean "${secret}.dec" 2>&1 >/dev/null && \
+"${HELM_CMD}" secrets clean "${secret}.dec" > /dev/null || exit 1 && \
 mode="specified .dec file"
 test_clean "${secret}" "${mode}"
 echo -e "${YELLOW}+++${NOC} Once again Encrypt and Test"
-"${HELM_CMD}" secrets enc "${secret}" 2>&1 >/dev/null && \
+"${HELM_CMD}" secrets enc "${secret}" > /dev/null || exit 1 && \
 test_encryption "${secret}"
 }
 

--- a/test.sh
+++ b/test.sh
@@ -5,8 +5,9 @@ GREEN='\033[0;32m'
 BLUE='\033[0;34m'
 YELLOW='\033[1;33m'
 NOC='\033[0m'
+ALREADY_ENC="Already Encrypted"
 SECRETS_REPO="https://github.com/futuresimple/helm-secrets"
-HELM_CMD="helm"
+HELM_CMD="helm-wrapper"
 
 trap_error() {
     local status=$?
@@ -71,12 +72,27 @@ else
 fi
 }
 
+test_already_encrypted() {
+if [[ "${enc_res}" == *"${ALREADY_ENC}"* ]];
+then
+    echo -e "${GREEN}[OK]${NOC} Already Encrypted"
+else
+    echo -e "${RED}[FAIL]${NOC} Not Encrypted or re-encrypted. Should be already encrypted with no re-encryption."
+    exit 1
+fi
+}
+
+
 test_helm_secrets() {
 echo -e "${YELLOW}+++${NOC} ${BLUE}Testing ${secret}${NOC}"
 
 echo -e "${YELLOW}+++${NOC} Encrypt and Test"
 "${HELM_CMD}" secrets enc "${secret}" > /dev/null || exit 1 && \
 test_encryption "${secret}"
+
+echo -e "${YELLOW}+++${NOC} Test if 'Already Encrypted' feature works"
+enc_res=$("${HELM_CMD}" secrets enc "${secret}" | grep "${ALREADY_ENC}")
+test_already_encrypted "${enc_res}"
 
 echo -e "${YELLOW}+++${NOC} View encrypted Test"
 test_view "${secret}"

--- a/test.sh
+++ b/test.sh
@@ -6,6 +6,7 @@ BLUE='\033[0;34m'
 YELLOW='\033[1;33m'
 NOC='\033[0m'
 SECRETS_REPO="https://github.com/futuresimple/helm-secrets"
+HELM_CMD="helm"
 
 test_encryption() {
 result=$(cat < "${secret}" | grep -Ec "(40B6FAEC80FD467E3FE9421019F6A67BB1B8DDBE|4434EA5D05F10F59D0DF7399AF1D073646ED4927)")
@@ -22,7 +23,7 @@ fi
 }
 
 test_view() {
-result_view=$(helm-wrapper secrets view "${secret}" | grep -Ec "(40B6FAEC80FD467E3FE9421019F6A67BB1B8DDBE|4434EA5D05F10F59D0DF7399AF1D073646ED4927)")
+result_view=$(${HELM_CMD} secrets view "${secret}" | grep -Ec "(40B6FAEC80FD467E3FE9421019F6A67BB1B8DDBE|4434EA5D05F10F59D0DF7399AF1D073646ED4927)")
 if [ "${result_view}" -gt 0 ];
 then
     echo -e "${RED}[FAIL]${NOC} Decryption failed"
@@ -60,24 +61,24 @@ fi
 test_helm_secrets() {
 echo -e "${YELLOW}+++${NOC} ${BLUE}Testing ${secret}${NOC}"
 echo -e "${YELLOW}+++${NOC} Encrypt and Test"
-helm-wrapper secrets enc "${secret}" 2>&1 >/dev/null && \
+"${HELM_CMD}" secrets enc "${secret}" 2>&1 >/dev/null && \
 test_encryption "${secret}"
 echo -e "${YELLOW}+++${NOC} View encrypted Test"
 test_view "${secret}"
 echo -e "${YELLOW}+++${NOC} Decrypt"
-helm-wrapper secrets dec "${secret}" 2>&1 >/dev/null && \
+"${HELM_CMD}" secrets dec "${secret}" 2>&1 >/dev/null && \
 test_decrypt "${secret}" && \
 cp "${secret}.dec" "${secret}"
 echo -e "${YELLOW}+++${NOC} Cleanup Test"
-helm-wrapper secrets clean "$(dirname ${secret})" 2>&1 >/dev/null && \
+"${HELM_CMD}" secrets clean "$(dirname ${secret})" 2>&1 >/dev/null && \
 mode="directory"
 test_clean "${secret}" "${mode}" && \
 cp "${secret}" "${secret}.dec" && \
-helm-wrapper secrets clean "${secret}.dec" 2>&1 >/dev/null && \
+"${HELM_CMD}" secrets clean "${secret}.dec" 2>&1 >/dev/null && \
 mode="specified .dec file"
 test_clean "${secret}" "${mode}"
 echo -e "${YELLOW}+++${NOC} Once again Encrypt and Test"
-helm-wrapper secrets enc "${secret}" 2>&1 >/dev/null && \
+"${HELM_CMD}" secrets enc "${secret}" 2>&1 >/dev/null && \
 test_encryption "${secret}"
 }
 
@@ -86,7 +87,7 @@ if [ "$(helm plugin list | tail -n1 | cut -d ' ' -f 1 | grep -c "secrets")" -eq 
 then
     echo -e "${GREEN}[OK]${NOC} helm-ecrets plugin installed"
 else
-    helm plugin install "${SECRETS_REPO}" 2>/dev/null
+    "${HELM_CMD}" plugin install "${SECRETS_REPO}" 2>/dev/null
     echo -e "${RED}[FAIL]${NOC} No helm-secrets plugin aboting"
     exit 1
 fi


### PR DESCRIPTION
Now no need to add .dec for secrets in -f just type your encrypted file and all will be done transparently.
Multiple fixes and cleanup in secrets.sh and wrapper.sh.
Test improvements.