### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ This will prevent committing decrypted files without sops metadata.
 ```
 #!/bin/sh
 
-for FILE in $(git diff-index HEAD | grep <your vars dir> | grep "secrets.y" | cut -f2 -d$'\t'); do
-    if file "$FILE" | grep -q -C10000 "sops:" | grep -q "version:"
+for FILE in $(git diff-index HEAD --name-only | grep <your vars dir> | grep "secrets.y"); do
+    if [ -f "$FILE" ] && ! grep $FILE -C10000 "sops:" | grep -q "version:"; then
     then
         echo "!!!!! $FILE" 'File is not encrypted !!!!!'
         echo "Run: helm secrets enc <file path>"

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ This will prevent committing decrypted files without sops metadata.
 #!/bin/sh
 
 for FILE in $(git diff-index HEAD --name-only | grep <your vars dir> | grep "secrets.y"); do
-    if [ -f "$FILE" ] && ! grep $FILE -C10000 "sops:" | grep -q "version:"; then
+    if [ -f "$FILE" ] && ! grep -C10000 "sops:" $FILE | grep -q "version:"; then
     then
         echo "!!!!! $FILE" 'File is not encrypted !!!!!'
         echo "Run: helm secrets enc <file path>"


### PR DESCRIPTION
The commit hook was not functional on OSX.  The `file` command's output is not the content of the file, rather it's the name and file type information.  

Instead: 
- used the `--name-only` flag on `diff-index` to simplify the statement
- customized to check if file exists (could have been deleted) and then grep the contents of the file. 
- Took off the `-q` option for the first grep so that the `version` grep has something to use