### PR TITLE
search bash using the env for portability

### DIFF
--- a/install-binary.sh
+++ b/install-binary.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SOPS_VERSION="2.0.9"
 

--- a/secrets.sh
+++ b/secrets.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # colors
 RED='\033[0;31m'


### PR DESCRIPTION
/bin is not always where the binary is located at. *BSD is an example and when the user has multiple bash (macOS)