### PR TITLE
UPDATE sha to be correct for mozilla/sops 3.0.0

### DIFF
--- a/install-binary.sh
+++ b/install-binary.sh
@@ -4,7 +4,7 @@ set -ueo pipefail
 
 SOPS_VERSION="3.0.0"
 SOPS_DEB_URL="https://github.com/mozilla/sops/releases/download/${SOPS_VERSION}/sops_${SOPS_VERSION}_amd64.deb"
-SOPS_DEB_SHA="e36760cbbe800d305818acb1f3c7d63e418d84b7a58d4c9d39d0c3de34868d91"
+SOPS_DEB_SHA="5254073f98c86f20a49d46d38c75409ddaef8993b9b5401ff4b4e3fc1af6c19e"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'


### PR DESCRIPTION
The sha is incorrect again. Can I add a travis test to this plugin to prevent this happening?