### PR TITLE
Use trap to catch exit of subshell and run cleanup

### DIFF
--- a/wrapper.sh
+++ b/wrapper.sh
@@ -92,6 +92,7 @@ function helm_cmd {
     echo ""
     trap 'cleanup $@' INT TERM EXIT
     $(echo "${HELM_CMD} $*" | sed -e 's/secrets.yaml/secrets.yaml.dec/g') >&3
+    local status=$?
     if [ "$status" -ne 0 ]; then
         echo ""
         cleanup "$@"

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -90,17 +90,8 @@ function cleanup {
 
 function helm_cmd {
     echo ""
+    trap 'cleanup $@' INT TERM EXIT
     $(echo "${HELM_CMD} $*" | sed -e 's/secrets.yaml/secrets.yaml.dec/g') >&3
-    local status=$?
-    if [ "$status" -ne 0 ]; then
-        echo ""
-        cleanup "$@"
-        exit 1
-    else
-        echo ""
-        cleanup "$@"
-        exit 0
-    fi
 }
 
 case "${CURRENT_COMMAND}" in

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -92,6 +92,15 @@ function helm_cmd {
     echo ""
     trap 'cleanup $@' INT TERM EXIT
     $(echo "${HELM_CMD} $*" | sed -e 's/secrets.yaml/secrets.yaml.dec/g') >&3
+    if [ "$status" -ne 0 ]; then
+        echo ""
+        cleanup "$@"
+        exit 1
+    else
+        echo ""
+        cleanup "$@"
+        exit 0
+    fi
 }
 
 case "${CURRENT_COMMAND}" in


### PR DESCRIPTION
As explained here https://github.com/futuresimple/helm-secrets/issues/29 the cleanup handler is not being executed, I'm not a bash expert so this might not be the best approach but seems to be working so far.

```
$ helm-wrapper upgrade my-releasev1 myrepo/mychart --install --namespace myns --values helm_vars/secrets.yaml
>>>>>> Decrypt
Decrypting helm_vars/secrets.yaml
[GCPKMS]	 WARN[0001] Decryption succeeded                          resourceID=projects/myproject/locations/global/keyRings/mykeyring/cryptoKeys/mykey
[SOPS]	 INFO[0001] Data key recovered successfully              

Error: UPGRADE FAILED: render error in "mychart/templates/secrets.yaml": template: mychart/templates/secrets.yaml:12:64: executing "mychart/templates/secrets.yaml" at <b64enc>: wrong type for value; expected string; got float64
>>>>>> Cleanup
removed './helm_vars/secrets.yaml.dec'
```
Regards