### PR TITLE
Remove unused LINUX_DISTRO variable

### DIFF
--- a/install-binary.sh
+++ b/install-binary.sh
@@ -33,11 +33,6 @@ else
 
     # Try to install sops.
 
-    if [ "$(uname)" == "Linux" ];
-    then
-       LINUX_DISTRO="$(lsb_release -is)"
-    fi
-
     ### Mozilla SOPS binary install
     if [ "$(uname)" == "Darwin" ];
     then


### PR DESCRIPTION
The variable assignment referenced `lsb_release`, which doesn't exist in the alpine linux distro.

Fixes #43