### PR TITLE
Install sops on non-debian based distros as well

### DIFF
--- a/install-binary.sh
+++ b/install-binary.sh
@@ -2,9 +2,11 @@
 
 set -ueo pipefail
 
-SOPS_VERSION="3.0.0"
+SOPS_VERSION="3.0.4"
 SOPS_DEB_URL="https://github.com/mozilla/sops/releases/download/${SOPS_VERSION}/sops_${SOPS_VERSION}_amd64.deb"
-SOPS_DEB_SHA="e36760cbbe800d305818acb1f3c7d63e418d84b7a58d4c9d39d0c3de34868d91"
+SOPS_DEB_SHA="9d9f319882ba05e7050be91bdfc396167ac9b00e2e6f634a647d55ac97915bb6"
+SOPS_LINUX_URL="https://github.com/mozilla/sops/releases/download/${SOPS_VERSION}/sops-${SOPS_VERSION}.linux"
+SOPS_LINUX_SHA="e185d2752defdcb18c054f67682a6684c72d6a6bf2341f6bef1dd7d33a110459"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -21,6 +23,14 @@ case "${HELM_BIN}" in
         HELM_DIR="$(dirname ${HELM_BIN})"
         ;;
 esac
+
+get_sha_256 () {
+    if command -v sha256sum > /dev/null; then res=$(sha256sum $1)
+    elif command -v shasum > /dev/null; then res=$(shasum -a 256 $1)
+    else res=$(/usr/bin/shasum -a 256 $1)
+    fi
+    echo $res | cut -d ' ' -f 1
+}
 
 # Install the helm wrapper in the same dir as helm itself. That's not
 # guaranteed to work, but it's better than hard-coding it.
@@ -46,16 +56,24 @@ else
     then
         if which dpkg;
         then
-            curl -L "${SOPS_DEB_URL}" > /tmp/sops.deb
-            if [ "$(/usr/bin/shasum -a 256 /tmp/sops.deb | cut -d ' ' -f 1)" == "${SOPS_DEB_SHA}" ];
+            curl -sL "${SOPS_DEB_URL}" > /tmp/sops
+            if [ "$(get_sha_256 /tmp/sops)" == "${SOPS_DEB_SHA}" ];
             then
-                sudo dpkg -i /tmp/sops.deb;
+                sudo dpkg -i /tmp/sops;
             else
                 echo -e "${RED}Wrong SHA256${NOC}"
             fi
         else
-            echo -e "${RED}Sorry only installation via dpkg (aka Debian distros) is currently supported${NOC}"
+            curl -sL "${SOPS_LINUX_URL}" > /tmp/sops
+            if [ "$(get_sha_256 /tmp/sops)" == "${SOPS_LINUX_SHA}" ];
+            then
+                chmod +x /tmp/sops
+                mv /tmp/sops /usr/local/bin/
+            else
+                echo -e "${RED}Wrong SHA256${NOC}"
+            fi
         fi
+        rm /tmp/sops 2>/dev/null || true
     else
         echo -e "${RED}No SOPS package available${NOC}"
         exit 1


### PR DESCRIPTION
Also updates sops to `3.0.4` (not `3.0.5` as that release wasn't available for debian)

Fixes #43

Depends on #45 being merged