### PR TITLE
Do not delete decrypted files recursively

### DIFF
--- a/secrets.sh
+++ b/secrets.sh
@@ -255,15 +255,13 @@ clean() {
   chart="$1"
   vars_load "$chart"
   basedir="$(dirname ${templates_dir})"
-  while read dec_file;
-  do
+  dec_file="${yml}${DEC_SUFFIX}"
   if [ -f "${dec_file}" ];
   then
      rm -v  "${dec_file}"
   else
      echo "Nothing to Clean"
   fi
-  done < <(find "${basedir}" -type f -name "*.yaml${DEC_SUFFIX}" )
 }
 
 view_helper() {


### PR DESCRIPTION
This is a proposal to fix issue #55. It works fine for our use case, but I'm not sure how it would affect the use case to decrypt "embedded" charts, as I haven't seen this workflow working at all. So, please be careful not to break that process (don't know if you have tests for this).