### PR TITLE
Compatibility with skaffold

### DIFF
--- a/secrets.sh
+++ b/secrets.sh
@@ -215,7 +215,7 @@ encrypt_helper() {
     [[ -e "$yml" ]] || { echo "File does not exist: $dir/$yml"; exit 1; }
     local ymldec=$(sed -e "s/\\.yaml$/${DEC_SUFFIX}/" <<<"$yml")
     [[ -e $ymldec ]] || ymldec="$yml"
-    
+
     if [[ $(grep -C10000 'sops:' "$ymldec" | grep -c 'version:') -gt 0 ]]
     then
 	echo "Already encrypted: $ymldec"
@@ -380,7 +380,7 @@ options='$options'
 longoptions='$longoptions'
 EOF
     fi
-    
+
     # parse command line
     local parsed # separate line, otherwise the return value of getopt is ignored
     # if parsing fails, getopt returns non-0, and the shell exits due to "set -e"
@@ -395,7 +395,7 @@ EOF
 	case "$1" in
 	    --)
 		# skip --, and what remains are the cmd args
-		shift 
+		shift
 		break
 		;;
             -f|--values)
@@ -420,7 +420,12 @@ EOF
 
     # run helm command with args and opts in correct order
     set +e # ignore errors
+
+    # If cmdopts isn't set then default it to an empty string
+    : "${cmdopts:=''}"
+
     ${HELM_BIN} ${TILLER_HOST:+--host "$TILLER_HOST" }"$cmd" $subcmd "$@" "${cmdopts[@]}"
+    EXIT_STATUS=$?
 
     # cleanup on-the-fly decrypted files
     [[ ${#decfiles[@]} -gt 0 ]] && rm -v "${decfiles[@]}"
@@ -483,7 +488,7 @@ case "${1:-help}" in
 	fi
 	clean "$2"
 	;;
-    install|upgrade|lint|diff)
+    install|upgrade|lint|diff|dep|get|delete)
 	helm_command "$@"
 	;;
     --help|-h|help)
@@ -495,4 +500,8 @@ case "${1:-help}" in
 	;;
 esac
 
-exit 0
+if [ -z ${EXIT_STATUS+x} ]; then
+    exit 0
+else
+    exit $EXIT_STATUS
+fi


### PR DESCRIPTION
updated available commands in helm-secrets and have program exit with the exit code of the executed helm command to make this plugin compatable with skaffold

This PR will make helm secrets compatible with skaffold by allow the dep, get, and delete commands to be used with helm secrets. These commands are used by skaffold and although I've tried to see if their code could be modified to selectively use helm secrets on certain commands it was easier to go this route.

I also pass through the exit code of the helm command since thats used by skaffold as well.
