### PR TITLE
Added support for helm template command

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Available Commands:
   lint          wrapper that decrypts secrets[.*].yaml files before running helm lint
   diff          wrapper that decrypts secrets[.*].yaml files before running helm diff
                   (diff is a helm plugin)
+  template      wrapper that decrypts secrets[.*].yaml files before running helm template
 ```
 
 By convention, files containing secrets are named `secrets.yaml`, or anything beginning with "secrets." and ending with ".yaml". E.g. `secrets.test.yaml` and `secrets.prod.yaml`.
@@ -276,6 +277,7 @@ Running helm to install/upgrade chart with our secrets files is simple with the 
   upgrade       run "helm upgrade" with decrypted secrets files
   lint          run "helm lint" with decrypted secrets files
   diff          run "helm diff" with decrypted secrets files
+  template      run "helm template" with decrypted secrets files
 ```
 
 The wrapper enables you to call these helm commands with on-the-fly decryption of secrets files passed as `-f` or `--values` arguments. Instead of calling e.g. `helm install ...` you can call `helm secrets install ...` to get on-the-fly decryption.

--- a/secrets.sh
+++ b/secrets.sh
@@ -43,6 +43,7 @@ Available Commands:
   lint		wrapper that decrypts secrets[.*].yaml files before running helm lint
   diff		wrapper that decrypts secrets[.*].yaml files before running helm diff
                   (diff is a helm plugin)
+  template  wrapper that decrypts secrets[.*].yaml files before running helm template
 
 EOF
 }
@@ -193,6 +194,23 @@ Example:
 
 Typical usage:
   $ ${HELM_BIN} secrets diff upgrade i1 stable/nginx-ingress -f values.test.yaml -f secrets.test.yaml
+
+EOF
+}
+
+template_usage() {
+    cat <<EOF
+Run helm template on a chart
+
+"template" is a helm plugin. This is a wrapper for the "helm template" command. It
+will detect -f and --values options, and decrypt any secrets.*.yaml files
+before running "helm template".
+
+Example:
+  $ ${HELM_BIN} secrets template <HELM TEMPLATE OPTIONS>
+
+Typical usage:
+  $ ${HELM_BIN} secrets template ./my-chart -f values.test.yaml -f secrets.test.yaml
 
 EOF
 }
@@ -483,7 +501,7 @@ case "${1:-help}" in
 	fi
 	clean "$2"
 	;;
-    install|upgrade|lint|diff)
+    install|upgrade|lint|diff|template)
 	helm_command "$@"
 	;;
     --help|-h|help)


### PR DESCRIPTION
I think it's useful to have the `helm template` command wrapped so that a user can render the helm output to file for uses on other machines without helm or for backup.