### PR TITLE
make clean more portable

### DIFF
--- a/secrets.sh
+++ b/secrets.sh
@@ -339,7 +339,7 @@ clean() {
 	return
     fi
     local basedir="$1"
-    find "$basedir" -type f -name "secrets*${DEC_SUFFIX}" -print0 | xargs -r0 rm -v
+    find "$basedir" -type f -name "secrets*${DEC_SUFFIX}" -exec rm -v {} \;
 }
 
 helm_wrapper() {


### PR DESCRIPTION
`xargs -r` is gnu specific and fails on bsd (macos).  Using exec is more portable.