### PR TITLE
Re-encrypt examples with SOPS 3.2.0

### DIFF
--- a/example/helm_vars/projectX/production/us-east-1/java-app/secrets.yaml
+++ b/example/helm_vars/projectX/production/us-east-1/java-app/secrets.yaml
@@ -1,31 +1,31 @@
-secret_production_projectx: ENC[AES256_GCM,data:h39e3ikBav2PNKjBMXw=,iv:EU42t6AX8RNdS2QUyE1+QcsSQuSFoOSzKuMunvUJsP4=,tag:/dRrsLyZfSwXRGh1MN2rvA==,type:str]
+secret_production_projectx: ENC[AES256_GCM,data:NUSh2U7MeE9Ilg6zuUk=,iv:CVAqiUQV460zJ2J2RCcbvwxWbkF0tomXz/GI24RuDXE=,tag:lpCPR5jXR9t6tNh5HzxQrA==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
-    lastmodified: '2018-10-23T19:50:37Z'
-    mac: ENC[AES256_GCM,data:/qQ3fuWzhX3d6fh4IpfEJjMcrKHuzqU9a34gFvyoUiK9SjyKBWLatl3a/DHLiaA9LL8oU33KnSfdm5PGoL/llemMRu3VPR0wLfq/Zp6W2DRBkPNMS/+UIDP4YA2NMsx1UscmCsSgKrFZ2I2C1NBwg//LJd+lL2dgZ7AJGKSYHEE=,iv:DeroeWinqSIHrDR88ekn2pPKNODt2mM139ToAiVyZdA=,tag:SteaPpkmB+09M7XT0Bwh5g==,type:str]
+    lastmodified: '2019-03-29T11:02:08Z'
+    mac: ENC[AES256_GCM,data:IygJhBcNtb+3hb0J/DlY01XWYZFfwGQxfXGCuYiqFiMreZ91RL8PATfuQsOuUqLQdubuFJnnCGxW1rNwpqIXaUPjTN1IjUs031ALs3VSu+GGmAm9VL37d4dBbP3m4YYzhgV5m/Mn5Z19H59KcxjaLuujIBaPDztgOn211Ijkui8=,iv:kQDdkQODDg58vYXG90XjuM1ATzYHBCC7Lem5/pllX5E=,tag:MbJuvLqLW57RO/2C5g4wVA==,type:str]
     pgp:
-    -   created_at: '2018-10-23T19:50:36Z'
+    -   created_at: '2019-03-29T11:02:08Z'
         enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            wcFMAxYpv4YXKfBAARAAo//JKgzOXoBNp7hdIqkkr8VOgxwR6pn3YYvSm9zf2tzk
-            BczA6986VRsLqpf2eYINcGJ8/ZCIuzLOT3iFAByuZxP5i0F+9n/WAFRt/nsW+Goq
-            f3WhIdraBeJFa37eAVDADDY5Ks1hDPJgsUdl+guXMmBX6YJG/YtofZCDVSGQOTcB
-            SqYuyxj3rnE+0D64P1K41LBQGJRi+LzaQ5JzFRCmH6RFcGXClzwZCO3PC0xKmNDE
-            fULgyIPdLDq4XiLnYSGJgqJ2Zz7ByxJddKyPSIULn8iREUVDxJpA1G2BF7JESpLz
-            t9bkjuwV/b6M7k0UKSjW5leDF8lkUjj/avfm6ZpjCc8Jdoq2klLs1XcKxyile7h5
-            416W9ITIsiXfsBXYrgLDJh6SdQBIyW/JIzLL+rtLRNmqU3p+3ugsHrd6Oi1soZnn
-            F+ZIiBggXN/Lh7yPVErBOnBNNpN56s1ch8x/rDZYbMUfX9gdfPIxWqnMzBxhiVYZ
-            G1rtSH3+yVs5bXdvtc7hlGgzumt18lhk1WEHsVxIVOXUpAoFrgewVtt++1d4LxGA
-            lmlmhYMb4ubTjsiZdSwq35Tamo0vXjvRhIPRvn1cm2cOt8AU3M6WV4GbZ/a9GS4Z
-            7X/gnHBMIQbYO2in6u427J4V22JrqZQ/0s39fTgwT06NJ2Vu39FSkPXjsvTrq2PS
-            4AHkDRQozeNXNeuiFXEza4Nz9+HcH+DM4KHhNDLgYuJGSI2I4I/lLxZDZHMOunpT
-            Ke2Ss7QJSZZoZ4L+OE5tUQYDXMgYXEvgUeTNXfO/EH+w64HiV7bGxowp4rHwLerh
-            kTcA
-            =pv4b
+            wcFMAxYpv4YXKfBAARAAAA8gRfuMZviZ+4kpzEOafKYT7kQ6QSqd/TGdgiZHtJFl
+            p5X0L8NJgXcgr6TNuBQF8f2AUy2IA0lfPfgESMofRD510Js0c7+W8YCrdIIV2kt7
+            wgqrzGFJAMmdbfOyFPCCYQJ/4HEolRvyxuDDfVPcNFxbiPqVeTnPCEZ0fMmsm26o
+            0XWDdKJ7qz5fDA/pi/9zDOsH5nBgksXpdlLGCUjGb1256FadIeYyX1L7ZFDW7jm9
+            IvwU9TQUlJFQ/VPsJPoahPujIVcgRyFSi14vUd9tYglr8cLnJJlFpD1rnb/plKea
+            O1mu7HYQFAdHmCHNtaooHD1tIsrZbCT8SG1qDOif3q8hCDFdLh9QknljTAu/pi3r
+            OMR3opOxw+0ZOFKwaum4iBEG2bDLvDAF574r0HwLWrRvYFvPQLM/ZE9tB6KPBaD4
+            iCm94HgUAPJsVSuuGXRpkkzixGVf3Ozt3CE4Sv3FFwtTBoCFGJxzAQVoYvjaXDjA
+            jZwFTfJoCMmXoq3tHoTEdTJdtvaoGXk2N8n7BZhwhj8jnOftFjhGUaJZggvC2qGT
+            00IqROarjKpoErVvcVxkgPpFa4HLyhNRBdaU3ECet4dNslM+P4j/i1ojNn1BYfG+
+            U5tXFyzp/vQd4MVVhLC+vyGLgQovwm1LXzghsXFHJYICaPewU0ad+qNZGozZjHrS
+            4AHknsSb6QLyJKL6Pn5g/nvrfeEBZeDU4KHh3tHgYuKCnFxp4KTlOoLn0zq7FF7V
+            icU1zn8CpnjF7Y7ofwDhVdgUjnzdQRvgKuSsDnaoZig1t/y9Si1YaEsx4jXbVnjh
+            fREA
+            =rpBY
             -----END PGP MESSAGE-----
         fp: 4434EA5D05F10F59D0DF7399AF1D073646ED4927
     unencrypted_suffix: _unencrypted
-    version: 3.1.1
+    version: 3.2.0

--- a/example/helm_vars/projectX/production/us-east-1/java-app/secrets.yaml
+++ b/example/helm_vars/projectX/production/us-east-1/java-app/secrets.yaml
@@ -1,30 +1,31 @@
-secret_production_projectx: ENC[AES256_GCM,data:kQWVuSxOKzn2go4nbX0=,iv:OyaCipiCbwoggYRLdM5Z3dEHXEJKSRFohG/l9ATt6oM=,tag:1n9IPZRY+hmLqAJz4/uEZQ==,type:str]
+secret_production_projectx: ENC[AES256_GCM,data:h39e3ikBav2PNKjBMXw=,iv:EU42t6AX8RNdS2QUyE1+QcsSQuSFoOSzKuMunvUJsP4=,tag:/dRrsLyZfSwXRGh1MN2rvA==,type:str]
 sops:
     kms: []
     gcp_kms: []
-    lastmodified: '2017-11-02T21:33:35Z'
-    mac: ENC[AES256_GCM,data:2WNkuIK/ImtGRvnYIRIs6tYofxa2m91e89gXCVxXFsE0clOLO2lY/7ujOwiGBNiAt6k5zhU78/yn/TA6IQmGDg9wnQ8aZMDjWV9NatFfqAyHRSWC7KM8JG+LJD3U1GItPcnTHKxAbltzvxWfMmYOIbRa0D58rRwZdHxVmGnHqgY=,iv:f+7CmAFp28IGRLwX/kihVxPWEN9yyCIhMPqPLEYg90U=,tag:0gXp5bVHK4iqUcsbZWEe7A==,type:str]
+    azure_kv: []
+    lastmodified: '2018-10-23T19:50:37Z'
+    mac: ENC[AES256_GCM,data:/qQ3fuWzhX3d6fh4IpfEJjMcrKHuzqU9a34gFvyoUiK9SjyKBWLatl3a/DHLiaA9LL8oU33KnSfdm5PGoL/llemMRu3VPR0wLfq/Zp6W2DRBkPNMS/+UIDP4YA2NMsx1UscmCsSgKrFZ2I2C1NBwg//LJd+lL2dgZ7AJGKSYHEE=,iv:DeroeWinqSIHrDR88ekn2pPKNODt2mM139ToAiVyZdA=,tag:SteaPpkmB+09M7XT0Bwh5g==,type:str]
     pgp:
-    -   created_at: '2017-11-02T21:33:35Z'
+    -   created_at: '2018-10-23T19:50:36Z'
         enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            wcFMAxYpv4YXKfBAARAAohqBHDTFnqSSkgAUpGm9A8Ij0T0HYi8H08SRkn56edtf
-            itSbZNHh+O14yxv4864vvN1X73OMdLJNd+EnNKkpXJ3dPR0L4t4YfiHi79V9fIzR
-            BEPWbcIa07nj07LfnVRYhwOHJ3Qn85KTtVAu+pU2oTwIGP3lzZDxVk6IiZZFR64K
-            zrY0AFRvHPh0iIPk4XZC/V2MD/fAoRZ7Fvk2+MiagdEbkd1bta9kbheclhMqutav
-            +ZxQy5Gh3C7r2SQTGGh/GdAYtRUePqAatk8B8aRJI1vrd8OOLKAT473XeXgwtOQv
-            SonNEcRFegdK3VuNPtlLLjTBp0UbotKtXOZirn2pha/ONVNMBn3mGr0Fymxv6nx3
-            XsdvDspWOqS12frGz8o8YGaxKbFY2LVuOOJ5uJwqZygJKXnAQTjsHo51qSqMt3tS
-            28y37aSliB39H5CL8Pgj4UopIvUA4i5Wk9S3lbUmoS1QUsQi/jHHydFeAZWSszqB
-            NI7N9vnpJTinNdlVML1hSGOsAHOQNAw3lsKpaUm/akQYHpnKl8/y1IuNAiL7T/Yj
-            QU75u67miVk4dHR5yqKdbElnf1sFU9MNQD5L0gFH6Xtk8od96LuWk++tH16WGld/
-            x73expRhYIm/Lt/2c90mzcBgb6vTth4g/J3GQaEjwLrwuH0fS/6r+CEpO4uy4sLS
-            4AHkR9Oezoy5CJO6UuSPZc+JpOHdduAQ4N7hf3jgsuLa6jlx4PDlHxpPDZRQx92d
-            AybY5/z8no/HDhTe5Y1DjiXON5o9fyTgiOQi/i+a0toYhGSg2ofizMFX4kkF4Crh
-            /Y4A
-            =O215
+            wcFMAxYpv4YXKfBAARAAo//JKgzOXoBNp7hdIqkkr8VOgxwR6pn3YYvSm9zf2tzk
+            BczA6986VRsLqpf2eYINcGJ8/ZCIuzLOT3iFAByuZxP5i0F+9n/WAFRt/nsW+Goq
+            f3WhIdraBeJFa37eAVDADDY5Ks1hDPJgsUdl+guXMmBX6YJG/YtofZCDVSGQOTcB
+            SqYuyxj3rnE+0D64P1K41LBQGJRi+LzaQ5JzFRCmH6RFcGXClzwZCO3PC0xKmNDE
+            fULgyIPdLDq4XiLnYSGJgqJ2Zz7ByxJddKyPSIULn8iREUVDxJpA1G2BF7JESpLz
+            t9bkjuwV/b6M7k0UKSjW5leDF8lkUjj/avfm6ZpjCc8Jdoq2klLs1XcKxyile7h5
+            416W9ITIsiXfsBXYrgLDJh6SdQBIyW/JIzLL+rtLRNmqU3p+3ugsHrd6Oi1soZnn
+            F+ZIiBggXN/Lh7yPVErBOnBNNpN56s1ch8x/rDZYbMUfX9gdfPIxWqnMzBxhiVYZ
+            G1rtSH3+yVs5bXdvtc7hlGgzumt18lhk1WEHsVxIVOXUpAoFrgewVtt++1d4LxGA
+            lmlmhYMb4ubTjsiZdSwq35Tamo0vXjvRhIPRvn1cm2cOt8AU3M6WV4GbZ/a9GS4Z
+            7X/gnHBMIQbYO2in6u427J4V22JrqZQ/0s39fTgwT06NJ2Vu39FSkPXjsvTrq2PS
+            4AHkDRQozeNXNeuiFXEza4Nz9+HcH+DM4KHhNDLgYuJGSI2I4I/lLxZDZHMOunpT
+            Ke2Ss7QJSZZoZ4L+OE5tUQYDXMgYXEvgUeTNXfO/EH+w64HiV7bGxowp4rHwLerh
+            kTcA
+            =pv4b
             -----END PGP MESSAGE-----
         fp: 4434EA5D05F10F59D0DF7399AF1D073646ED4927
     unencrypted_suffix: _unencrypted
-    version: 3.0.0
+    version: 3.1.1

--- a/example/helm_vars/projectX/sandbox/us-east-1/java-app/secrets.yaml
+++ b/example/helm_vars/projectX/sandbox/us-east-1/java-app/secrets.yaml
@@ -1,30 +1,31 @@
-secret_sandbox_projectx: ENC[AES256_GCM,data:hTjfR7kVV3NHHeu65aNxJQ==,iv:XdZfVbnaa2d/GrA9aYywaToCkYJC2NgS2sNmziRGwQ8=,tag:C17Dsk/Z2/CGpQZWtvo6Sw==,type:str]
+secret_sandbox_projectx: ENC[AES256_GCM,data:OEHGo4z0wF+oEGoH7sPfXQ==,iv:5eD6AiJNH7gOxtTGL6vMJDcy2zHCm7z5P7lrJU1+G00=,tag:6PkEnZ20C+z211uC30V/hA==,type:str]
 sops:
     kms: []
     gcp_kms: []
-    lastmodified: '2017-11-02T21:33:37Z'
-    mac: ENC[AES256_GCM,data:cJv+67hiCLTNFETc1aDpAzVfgHe9NwnFiWER83UETYMTvRVU55Nmjo4Ra5PGt7MseFVoOg0tYt5lOBRjP87xHG+a0yGacUt07fm37FQ2LeghnNpTIL0PlbRLeNwsijY1NCWhdcQyEMe78Q6a1+vYvEn1nNwroFO6JxQWmrqQCuY=,iv:buTjo5ibHY3lvSkr4FRj9u9Dg8HT/0felMRBXKD13jw=,tag:/SM3vSMvqRCnXdWebj9t7A==,type:str]
+    azure_kv: []
+    lastmodified: '2018-10-23T19:50:26Z'
+    mac: ENC[AES256_GCM,data:HAmu0eV0CFuRGQhiAjVyO2LgQUxOu0/1hwPP8AOB0FyrivvwlnhuZXEpMvMMI4AhOwRrw8qwVKZbKlhKq9ZB16Kilgp57yGtxg7kfNQeTi2WypWxKXX7yi3ZhIuIXrWfFH9v4+0IniHAwgGD30khxiM1D/dKM7D35b2ADaMvIQg=,iv:A/bqivCIpp8U7ZoTf1s1b54XLVkTDQfk+veSHyFUfm8=,tag:X0b40UiFXFg7vV7MKascCg==,type:str]
     pgp:
-    -   created_at: '2017-11-02T21:33:37Z'
+    -   created_at: '2018-10-23T19:50:26Z'
         enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            wcFMAxYpv4YXKfBAARAAoVExGgdPxqYQYo8p2OCIoGwNIQEgRgge7juMI7O5LYfB
-            BEYx7lQ/7SyRY7xvfxMBgYZGoVuVCLqyYhn2t+YqTYgD5rRmdPe4Z4UrlI8Er0BW
-            hYKvWQtIWWlmBxqprjf9BDMKlETSLkpX2QtIeLUF/fgH0bHvBz7iBADrGee+JyWV
-            CY0MsE/TOnCoCIRxwRkneYCMRVPDmX7v73m/rSC32zTRYO8cwlD8eJrrsAn4H1xZ
-            9iYamvcfk9XxvasaxugXnX9qfQjUhRHLWknztgAZ7GiSZtVKjyUYyZQXF2Z0KU2o
-            KsAAmZHk4uwduXTlUWkbNhiglAXbTpjfhnPM/m3cSkORP0WPUDofnWOOyYUn97T+
-            GrjBtA2ePt8QSFcDIvhsNVKHvO2GpbHBRip2jdiIflH6gyXCAAj92hu2YSKRIbjS
-            joH+VUj0Wgs6ubtH05XfytC79hxVYSNYeGFOC9rJzmsTKidMBk+yGWLlSDJIcmjS
-            Azn26yoIkKtlnBAKJGZgauuiDkSv/K2PaURPdPaSLfE2LbzwC8AdmbR4UnP453NZ
-            xQRPU/O362JMQyG1flr1bmH9zBTm5ka+whYxG+DF8uE7onF4eVYQQ+R94jNMpX2J
-            lZMRql8t52r0VnAuMhqcgyH1s4tehi0M9sWsKpnpMclw2lK/mRIlJSQ0w1l/lKrS
-            4AHkACtuZUivERJQsDMd38FCmeED6OB34DPhO/PgIuILVKU84B3lT9Cr23cJsBL3
-            HR3F3m1ifIPfBh6Gz2AKIqjSe0f8JS7grOSIVEmKbFACg516hXTa2m9z4kpcmNjh
-            aXoA
-            =u8QR
+            wcFMAxYpv4YXKfBAARAAjP4LzWA1z7/+kkk2EoiCTW56npsnZzZbur87NjzShIBr
+            kO0E8w0ZXJFioIM0EighUmnFVerz4XB7q5VTQ4X7SVD2PXE1WCAFUZoWpJPLQ6bI
+            bZ052WyO5gFigIoQGlTZsCfoIstnkxmalrP5gIOJXtFfBFjIDuMOjjX/YWcJZy8i
+            qSROW04Mru7rhhxX5ZDubMCvjIF+r3KxaoKlSegnOCKq+XXQF9nMLyku+UUo0ZaD
+            DTODQwCL2zS/R8YgZrL1ZwNu7MQkGkuQJ5naOra3BC43OeOLS3SRhrO40LX56zDH
+            F0eLuE1nrlU0A6fAztAAUuNDcRF7Z3jDDGjQhUQ81D9JHyoKK6DtkiEfCrKhUoZt
+            Tzx8LDPdt4oNAlyllXRAnqz3BwrDE8f5V9aKPUXURb/Swhqzbn0l3gE1cVvkMO73
+            SBXiBhEKt3D6kQIhBujnANjLH2x1LuGq35A63YC7I2zuCteaAFnmzpYq/mMZZR3r
+            yCa7sWtHTOgOW0mKgCQG7EABUUFFelqeDim1yXra9Y2n12KfeaIUDfRXzmV5Eb6P
+            NYeC4OdfYx43tkKLnc72kp5RPDfgsZRBlUI5qZlFh1TaVoXB5U6xjwu2KmfJjaOj
+            4Hn+WIycLHxm6lnxVlzSurPio77KMhoa55p3+N4mV2fbevg5P2IQc0TBpKIrVhPS
+            4AHk7k0Wa0yxkCXL60F/O0Q+y+GnH+Bi4EvhlX/gTOKsxOpX4MDlEMX8zVJvc+94
+            hiKEBrVjBzlpiM8OPqRsDmIy15rKj9HgiOQjmkCbaepz3Iubw/JhutpT4v65WK3h
+            We0A
+            =ZjLI
             -----END PGP MESSAGE-----
         fp: 4434EA5D05F10F59D0DF7399AF1D073646ED4927
     unencrypted_suffix: _unencrypted
-    version: 3.0.0
+    version: 3.1.1

--- a/example/helm_vars/projectX/sandbox/us-east-1/java-app/secrets.yaml
+++ b/example/helm_vars/projectX/sandbox/us-east-1/java-app/secrets.yaml
@@ -1,31 +1,31 @@
-secret_sandbox_projectx: ENC[AES256_GCM,data:OEHGo4z0wF+oEGoH7sPfXQ==,iv:5eD6AiJNH7gOxtTGL6vMJDcy2zHCm7z5P7lrJU1+G00=,tag:6PkEnZ20C+z211uC30V/hA==,type:str]
+secret_sandbox_projectx: ENC[AES256_GCM,data:KSZG/XTW6Wy6RPJ5zIQMTA==,iv:1CbKkKCtk9ze6wmwK6rvfiZcjM6KuCFGUnc6JjtbXR4=,tag:heTaPsUsr2BtkasZ1Zj+/g==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
-    lastmodified: '2018-10-23T19:50:26Z'
-    mac: ENC[AES256_GCM,data:HAmu0eV0CFuRGQhiAjVyO2LgQUxOu0/1hwPP8AOB0FyrivvwlnhuZXEpMvMMI4AhOwRrw8qwVKZbKlhKq9ZB16Kilgp57yGtxg7kfNQeTi2WypWxKXX7yi3ZhIuIXrWfFH9v4+0IniHAwgGD30khxiM1D/dKM7D35b2ADaMvIQg=,iv:A/bqivCIpp8U7ZoTf1s1b54XLVkTDQfk+veSHyFUfm8=,tag:X0b40UiFXFg7vV7MKascCg==,type:str]
+    lastmodified: '2019-03-29T11:02:07Z'
+    mac: ENC[AES256_GCM,data:lGMVD/vMAQ1tC9nwhnskvDE+D9EDe6v/XfAu4MXZWLDaA4gpNgYCJTEvAihVoJIO4jxsbIlzvq35GDRu+mMQMRcxrBK584ZPLv8CXxFRCrfNHOpkKwY3GEQXsLBMq9zUtayYihijR72xyDKoOVpj+zEADwwRIK34/EWN7ht5d8Q=,iv:r2ObjVV9etc1qlv08C35b52kx42ZoVbJluVMA2h/iFk=,tag:WRN2uoL/J9frpaMNSVqUxg==,type:str]
     pgp:
-    -   created_at: '2018-10-23T19:50:26Z'
+    -   created_at: '2019-03-29T11:02:07Z'
         enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            wcFMAxYpv4YXKfBAARAAjP4LzWA1z7/+kkk2EoiCTW56npsnZzZbur87NjzShIBr
-            kO0E8w0ZXJFioIM0EighUmnFVerz4XB7q5VTQ4X7SVD2PXE1WCAFUZoWpJPLQ6bI
-            bZ052WyO5gFigIoQGlTZsCfoIstnkxmalrP5gIOJXtFfBFjIDuMOjjX/YWcJZy8i
-            qSROW04Mru7rhhxX5ZDubMCvjIF+r3KxaoKlSegnOCKq+XXQF9nMLyku+UUo0ZaD
-            DTODQwCL2zS/R8YgZrL1ZwNu7MQkGkuQJ5naOra3BC43OeOLS3SRhrO40LX56zDH
-            F0eLuE1nrlU0A6fAztAAUuNDcRF7Z3jDDGjQhUQ81D9JHyoKK6DtkiEfCrKhUoZt
-            Tzx8LDPdt4oNAlyllXRAnqz3BwrDE8f5V9aKPUXURb/Swhqzbn0l3gE1cVvkMO73
-            SBXiBhEKt3D6kQIhBujnANjLH2x1LuGq35A63YC7I2zuCteaAFnmzpYq/mMZZR3r
-            yCa7sWtHTOgOW0mKgCQG7EABUUFFelqeDim1yXra9Y2n12KfeaIUDfRXzmV5Eb6P
-            NYeC4OdfYx43tkKLnc72kp5RPDfgsZRBlUI5qZlFh1TaVoXB5U6xjwu2KmfJjaOj
-            4Hn+WIycLHxm6lnxVlzSurPio77KMhoa55p3+N4mV2fbevg5P2IQc0TBpKIrVhPS
-            4AHk7k0Wa0yxkCXL60F/O0Q+y+GnH+Bi4EvhlX/gTOKsxOpX4MDlEMX8zVJvc+94
-            hiKEBrVjBzlpiM8OPqRsDmIy15rKj9HgiOQjmkCbaepz3Iubw/JhutpT4v65WK3h
-            We0A
-            =ZjLI
+            wcFMAxYpv4YXKfBAARAAUCaamEEJbGWhWCiIiOeWGaKJYzd/FkC5Qvvv3yFl4YKt
+            6apRMA1/7u9nTEGzVnsH6CwgoU276Fj4oKjOiDuKdaTwEHC1gWZNT5EOll0Jh6ED
+            oQ2rAWexkk/A6hyGdn7tAh/7IAMQK5QIHI0Z+H88DPV8ZfbEC6NRlyepP/LUt92S
+            eVoH1aeUVyTEJVOwmvkKSkAEeQlP+iLJFOECyVO0T5NfnPj8E7OFvJ8Nv5kD1vec
+            wdYVfbRUIZwIySE6alduz2cjxuUBhpbLjMqIT25pL5uXoSzIrxKmvkVg1DInYYJ/
+            1radpOYIGJRJ1aMMfBYtNsL5rSRRjexiykgCm+ZG54SvUbnA8/KfsZLZiZqSxduD
+            k6YX8BAL6WzknJ0qjY3SxZ3tpu6FPBJH9U69z2sM0hFxXCBLOWfsQ3JXpQ+HKRUX
+            c4mlA3lBeOCLVefrJuhy1TjO9094yTEc/i+r9yG7xvLwzWlFSeFpf6ph0vvK+bYG
+            ITglOP9Ipy0T5cTzlKq3pCCLlBAUSRiVncHhspfnoFSSlTgN2kawbikpF1a7I/Qh
+            Mpe29nPBywq4LFzyOJrpOAD6n1HU+KQKp3qZCjhdxx8EawFlZqUF6j7qLkKTN1AQ
+            w43l9pfqS2FXVXuouLlqPcg/KjG+5lx+KFjb1l6cvpvtL0Jvr8YiJ64t75GLoPPS
+            4AHkTeYCfXmj7nRhZWZCuGVaxOFlCeDv4CjhyKfgr+IOF56v4NzlwZRMyKuOnr6R
+            0G8vX7H5t8XJPbUsgB99we6hRY911ZzgAORsusuyK6Aiv2+b58CnLXMp4huU1rTh
+            9L4A
+            =eUDm
             -----END PGP MESSAGE-----
         fp: 4434EA5D05F10F59D0DF7399AF1D073646ED4927
     unencrypted_suffix: _unencrypted
-    version: 3.1.1
+    version: 3.2.0

--- a/example/helm_vars/projectY/production/us-east-1/java-app/secrets.yaml
+++ b/example/helm_vars/projectY/production/us-east-1/java-app/secrets.yaml
@@ -1,30 +1,31 @@
-secret_production_projecty: ENC[AES256_GCM,data:2lnu3dLUuAyYDOxlTuw=,iv:LFoz74oMPOLKgbcUUleCyKTPo1GErXsUrVxYwR0OceI=,tag:L4iKy1OD8aBomAJ/7LFnUA==,type:str]
+secret_production_projecty: ENC[AES256_GCM,data:tGtjz5yKfWBxhuqqjl8=,iv:dGLZQzmwKptm868/SIf0RXHw2ZglIwFRJS+3Um49FHw=,tag:EooFt72/YpITvPmWpU5G9g==,type:str]
 sops:
     kms: []
     gcp_kms: []
-    lastmodified: '2017-11-02T21:33:38Z'
-    mac: ENC[AES256_GCM,data:bNfSjTSiQr11Kyky1/xwS2sdgTj/uOixzZDVR9R9y7Drb7ZLTQVWmU1EiE+EvLdIxv7NqtTbF3onGWKD3/EfD7P8K0km30Nio02OwpHfq+mUJxcNzoXebz5xGSvpgnkpgA5aJ9Akt74WNyBolRPkBQG8bhbDjb/GbCxZRKV/fBY=,iv:qXvAs1hhGEv/3+UH43ok2cDx7AOLrBlP4TS4EeFh48E=,tag:p7a1dA5hmNKlZyMN5THcug==,type:str]
+    azure_kv: []
+    lastmodified: '2018-10-23T19:50:59Z'
+    mac: ENC[AES256_GCM,data:PYD4KzOLNoFQ64RdT5PiqXYp4hXDgtfkFEJmfkMzgRfP5z+E4nYQAxWmY4vEwDVgDUqNr7RcLJ4I/FIUSonkN2GHc1F4LTp9Hfoo8Pa+l5ejql7vp3vItqTJ3ITk/rJiBAKwhixfGxBtpuiMYvJm1uOLHSBwNzNL61v4Nn/JE30=,iv:Uotp9ttUC4Ps5O8riGOl7FQA5kFYpUtbc4P+iscQvsg=,tag:tE7kAJgpwLj4ovZEfoSeoQ==,type:str]
     pgp:
-    -   created_at: '2017-11-02T21:33:38Z'
+    -   created_at: '2018-10-23T19:50:58Z'
         enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            wcFMAxzSiC7ZHNQZARAAK0lw7gN34aYCgvcXcxBeP7D1wm4jK7vOpzxuSOTxVNyT
-            mVoajWSaYwXIJUdfYEuMxojVkX/4lgpNd+4Twm5r/5md8u0Zn1CeBh849tXiQirl
-            OJrsXpMHK6spgGMoPQymdROuSPTpoi3PlHZyBUMfIqzEVTEiYV0xLhpDAfBjGG5Q
-            fTusPMHSSesGV5VVcfdKYDVp3tRxiD0CTBe1fox2SIuDx9hUOwaUsJnc9Y+ogKZB
-            QqriP7vCFOYTlQxINHAvKQleesKgDSYi2FTqEPkOmq3V/9IRcI5UKXB6oY1yZF3j
-            81pkLVYk5yL/Q006hfWKNUliW2WYZO+yJF82W8Ui64WKv2sNVmgHRKgtW2EezWlw
-            lQLrcopO8d6usFadOOhrRuYYsqmG/+yvuoN/HUaTj9NEBwAy6PYngNVwQX8sBSgx
-            jYnwd/4NCUfpailp7RQOLXyo5KaxMAorC5VP/BYoRLO/90Yfo839oShfFzW9i7LC
-            CNpFKvqo3374Si7oaELS9a/BwHpvyolsBjqWjbHXsC1sHPieV6/WRUGdTPED8gis
-            Fht3DdRf94H4eaKOf6FQxAboWH68f+OQH8HLwawkkDukvyOQC12YAHYry2vt7jgD
-            mvl/yYWfOKLwIpOhMWfROj1xEh0AD+jYdOrZniEgUgtLIozNhyRoZGhjcUg8rnvS
-            4AHk27p+CooJDPs+jpJnWekFEuHsOeDu4OThMnLgeOIzC7pX4Gvl8Ky1R8hTAU9o
-            txylcfl7u1i2v0TbAqEa0Jr8BcSY4/vgeOT473Ui9ls0BVBVgmMaOiZE4k501ubh
-            q8MA
-            =j5nd
+            wcFMAxzSiC7ZHNQZARAASvue6fXwQgWUoU4Qj4Qu2AUTATTpUg5cMrjAzPFptKku
+            fyQnvmRcEP6qLp5Mun3KiIT/YAetAIsqJ8FhaTiLDdX3RAqrsQ0Lyr6qveAhqN17
+            HGmtQPK1UyunGNygw4Cs5UiAcekktQx25q7qvQ48kiKMc/asGa9blQYv7K3AAE7X
+            fNyCnIN7f+ZOk9IvmbHb7bCz4/XXfYks2j5tKJf/Vtgoukp+K59AP2Hcd3788gPT
+            LCm904jVbSiJJ1xmBo86Rue/osauBSDdi0GKMM64pYqUGqRWyWANXX6qM4U1JSaW
+            kq76Ab5fhUWdqpPOgISFbbKEVuEj8IIjzCtHSs56hCTIKDwyTZuwYbPypV7MY+Bu
+            mM1UYFCF1oMuRqVRxWIEKbABG/njvByyCQ7U9D3wG0L0AqMLYQpXx1EENQ13QT5h
+            KozVoidnGnbCvOM0Aqq7hkHOxQuNeaDyLiScObvf26i5xlIp2XNcm1iY0Hoxx3ps
+            0BLs2mrhfg9hMV5tE5/QHz2DQVJv0hDFvuC+3Hz46iybxqQeblxX8vdXPJlsC1wG
+            5W4zZRs7YU+G6rGu/0L0XT1wA4XB/TSgOd+N0Mc4CAnMyW5uqiPkS7JKU6lNcQYy
+            0BiKjtC9Vdo5KQkHcS8sgci8aW3mfjWYHaWtFM8VXJOkOoRUrI8Jrmzd+DqVTTnS
+            4AHk/U7SU+euZnqF0b0RS0acOOHeVOCI4OXhDNLgsuKJ/hTl4APlTXTSwQbRWD3T
+            XriloZGKYymCq1eXh4z2d5ikvIUvjvDgROQ1IAyuMfKevb/5LWaBRYJm4kmTn7Lh
+            GuoA
+            =i7bp
             -----END PGP MESSAGE-----
         fp: 40B6FAEC80FD467E3FE9421019F6A67BB1B8DDBE
     unencrypted_suffix: _unencrypted
-    version: 3.0.0
+    version: 3.1.1

--- a/example/helm_vars/projectY/production/us-east-1/java-app/secrets.yaml
+++ b/example/helm_vars/projectY/production/us-east-1/java-app/secrets.yaml
@@ -1,31 +1,31 @@
-secret_production_projecty: ENC[AES256_GCM,data:tGtjz5yKfWBxhuqqjl8=,iv:dGLZQzmwKptm868/SIf0RXHw2ZglIwFRJS+3Um49FHw=,tag:EooFt72/YpITvPmWpU5G9g==,type:str]
+secret_production_projecty: ENC[AES256_GCM,data:0jcFuH/OjCjnXmaH6lM=,iv:i3KOj0uQPazU87Jb2T8RD7f3eUrKXOW9OsICuB4Rmco=,tag:VsrWeUmMiEgP/ZZvk7BrzQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
-    lastmodified: '2018-10-23T19:50:59Z'
-    mac: ENC[AES256_GCM,data:PYD4KzOLNoFQ64RdT5PiqXYp4hXDgtfkFEJmfkMzgRfP5z+E4nYQAxWmY4vEwDVgDUqNr7RcLJ4I/FIUSonkN2GHc1F4LTp9Hfoo8Pa+l5ejql7vp3vItqTJ3ITk/rJiBAKwhixfGxBtpuiMYvJm1uOLHSBwNzNL61v4Nn/JE30=,iv:Uotp9ttUC4Ps5O8riGOl7FQA5kFYpUtbc4P+iscQvsg=,tag:tE7kAJgpwLj4ovZEfoSeoQ==,type:str]
+    lastmodified: '2019-03-29T11:02:10Z'
+    mac: ENC[AES256_GCM,data:l8MS+OjSUrbaoIdlp7HxzPE3ApNyjxlK7ojuHdyjvBXXYUDuZ5gpLMtaeXxgjKNQaGtIeVOevpiENzOANkL7Hn+MtUJmmeTu7bx1hPQyxebGyLH/Y4DVAM8rY4mGZngTg4LYZcHuL3j9HBIUkf3WLSTqjYFMcbuDKqCCOPuyQf0=,iv:lSAmW9OPRoJeaNAtXFB7u/SPPIPfNJrIgUCD6yoBuR8=,tag:s2KAjECP055ZgDYBoagz5w==,type:str]
     pgp:
-    -   created_at: '2018-10-23T19:50:58Z'
+    -   created_at: '2019-03-29T11:02:10Z'
         enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            wcFMAxzSiC7ZHNQZARAASvue6fXwQgWUoU4Qj4Qu2AUTATTpUg5cMrjAzPFptKku
-            fyQnvmRcEP6qLp5Mun3KiIT/YAetAIsqJ8FhaTiLDdX3RAqrsQ0Lyr6qveAhqN17
-            HGmtQPK1UyunGNygw4Cs5UiAcekktQx25q7qvQ48kiKMc/asGa9blQYv7K3AAE7X
-            fNyCnIN7f+ZOk9IvmbHb7bCz4/XXfYks2j5tKJf/Vtgoukp+K59AP2Hcd3788gPT
-            LCm904jVbSiJJ1xmBo86Rue/osauBSDdi0GKMM64pYqUGqRWyWANXX6qM4U1JSaW
-            kq76Ab5fhUWdqpPOgISFbbKEVuEj8IIjzCtHSs56hCTIKDwyTZuwYbPypV7MY+Bu
-            mM1UYFCF1oMuRqVRxWIEKbABG/njvByyCQ7U9D3wG0L0AqMLYQpXx1EENQ13QT5h
-            KozVoidnGnbCvOM0Aqq7hkHOxQuNeaDyLiScObvf26i5xlIp2XNcm1iY0Hoxx3ps
-            0BLs2mrhfg9hMV5tE5/QHz2DQVJv0hDFvuC+3Hz46iybxqQeblxX8vdXPJlsC1wG
-            5W4zZRs7YU+G6rGu/0L0XT1wA4XB/TSgOd+N0Mc4CAnMyW5uqiPkS7JKU6lNcQYy
-            0BiKjtC9Vdo5KQkHcS8sgci8aW3mfjWYHaWtFM8VXJOkOoRUrI8Jrmzd+DqVTTnS
-            4AHk/U7SU+euZnqF0b0RS0acOOHeVOCI4OXhDNLgsuKJ/hTl4APlTXTSwQbRWD3T
-            XriloZGKYymCq1eXh4z2d5ikvIUvjvDgROQ1IAyuMfKevb/5LWaBRYJm4kmTn7Lh
-            GuoA
-            =i7bp
+            wcFMAxzSiC7ZHNQZARAATDA+rolBbJrsHLGqgjGDjFANuSiqQOcSYKRF5kFCi1Yj
+            dhHbH5psqVJmdsLQzQDrO5Lrx1Sq8vSzlj5rOA1wMnWbE8M+BzZt4vkvwMw3FOgO
+            IMco/FZUlSUUKe3V2pvMhax9BieJMgFVDYxEB4KI0EeZhqbC/wwGrK+7X0zni7bE
+            jdRhIZ1Xtci6gf24/i5ttA0jc8pRKcFouVJdAz5g79AbcK3Nxph+LlrKNliwRjYc
+            zFs6vnwOR+fOCpCdK9aJY1zG02I1OitRjXKfQUzbsjIG/o4P5gwxuyTm87mWl9Ov
+            rt1vxXWX8EVSBgYfTPC6Oq+gESl47wECGJflun+hlxD06k/16/Pvk6CtQBYF65ss
+            mZb+YAXtck6cxMPuBVaD3L6zs3tvWMl+fdaJb5CAXQLPsXAoOuN9yXCbd9+T1rLo
+            Y6Kn9ZoxTEJk+zN8VAhBuE0aZ/ktmaVXwU98NimuOXTbVt+9noXfgbzRMi+kPui6
+            SXg0IgSwOCSR/oRMk5gqgr3v2LKwMDw/2gdxxTTjCv4x/Mjaz4zmVIqTHM+oR0F/
+            eER4EgVFFN2N5QxcMU3NgGaPgq067F+xOlb1VlXnvxANMEoE9Vcp+nD2aVtsEX+t
+            5egy4xdJzhSIovWjxq4Y9QF0qRp52NYuOkDeadY/XavEjyTBLmp2AF0tpjwcPqbS
+            4AHkyZ1LXa8ja6zN9lCl8gAPWOHDS+Bl4PnhCOrgOuJQ8tNI4FblAT5gFlx5vTIb
+            +AGwfNODVhnB6QJywpHozYV5hxAWYCfgDuQLEaOpis7ypp483Gv9UqwO4tELnnnh
+            ZQMA
+            =Pb7g
             -----END PGP MESSAGE-----
         fp: 40B6FAEC80FD467E3FE9421019F6A67BB1B8DDBE
     unencrypted_suffix: _unencrypted
-    version: 3.1.1
+    version: 3.2.0

--- a/example/helm_vars/projectY/sandbox/us-east-1/java-app/secrets.yaml
+++ b/example/helm_vars/projectY/sandbox/us-east-1/java-app/secrets.yaml
@@ -1,31 +1,31 @@
-secret_sandbox_projecty: ENC[AES256_GCM,data:DQiceXJvxOnIYupIMGVb,iv:DnzOHPFgHPp/Uaj4mQMTs3INxfnntNWfMUV/5pgmRLE=,tag:sSNyH7Pc1wD9iMj6641glg==,type:str]
+secret_sandbox_projecty: ENC[AES256_GCM,data:AC3dznJbIJBZ7/r6kw2U,iv:uVeNY1dzRAvjyKqahhy2OrqI8sxWeLTqhOMdtVN3X30=,tag:qAImwVgVBnr4lwnS1Yu3iQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
-    lastmodified: '2018-10-23T19:50:47Z'
-    mac: ENC[AES256_GCM,data:/ZEzpJq6ky+CxtXkqKkRnrLPODsQh4QBlejxPImmwGguI+cEIJZihNecyyqFFOvnmM1nBAqpGna2vl3FhzVGcUOhkjPN8dxFAAK2+y1vs6hW87MXEWYp8p2BQjUV2nfWm8iCt7VN3c9Bx2yLaecOg9chYL0sM92k8GLNwODlGCI=,iv:Ls/dzjtbnflkDSCSt83OmJU1odVxJRKGaAvPvfPcgmE=,tag:1Ooi8+FhjU8Bhyl422WzvQ==,type:str]
+    lastmodified: '2019-03-29T11:02:09Z'
+    mac: ENC[AES256_GCM,data:aZIT/mClu2sx36vpRxzRRtlS3WM+2Qkb1mlhjhHjdrU1NqITFTPyBSemvilpxiF1bUdT5M8Y32dtRFoylsAnZ+w60DvaRynAOm2jL0PSzFq0iLo5W8oUWSPFmJv+/Ixc7SLtKpfjJO9qEt8ad0SipEHEFHc6gKpxMgMIDrbIeWc=,iv:0k7k++pPOFqDXNvOUYbt39MgkW0s2j5a7SnYcaK6WnA=,tag:hx7MixPps3ps7dThnJgcIw==,type:str]
     pgp:
-    -   created_at: '2018-10-23T19:50:47Z'
+    -   created_at: '2019-03-29T11:02:09Z'
         enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            wcFMAxzSiC7ZHNQZARAAKI6hbL7Amqr5yQWzo1sOQ4NuPdES+5RzQpR1FTARBd8r
-            B7hWQbFUh5D42B6KiqCM2Vfk/0UYj825jdr2XLVDsMJWYehoMh1Ibbn3Ulb0M56y
-            twJFCLR/4LaN3oWt05ZBnX4C2gQthnDPkBBDcsomEBUYZSW7wjjEHYGpAwjVys6m
-            GjO541Q1/Vz+IVT93YbRiUx2T3OEPnmsz82wPTttZPjG4F7fbjUEqjwJtfswsBHq
-            Q6vflzcikqPJYDoaOc/lnSoalwfSmfn8TECRiU9rivm7HVDIR67OWnQJd9HAwB0W
-            EVWfgzSDD4+n8VGHFTBuQRZJUciZ9BOQ4S4kZyo4immukcmuDqWvTmCky3XplIy9
-            GyMacnm85hEFyQVWvwbmenauvbH9QgxXKr7q1YIzM57fqnRA1wGLsZstOJy1S5Px
-            WoL8mpede0vno0SBdbbJQ3WjNiCnspa10s77I3u5+jCIdV7IySSQIiPhHsSP6iQi
-            xo1Hxl9ugRU3VgDBR1Cq9yCTTohS2ZG6Yk9SzgtIVI+Ab/OKRosecCpwCQ8pJ33l
-            zmGEYZs0EtJJi+DBq2Hy6wSM2NtkmFWiOVQxC3bYDn88yzsMnBXoDro4XRLNZwL0
-            Bu5PFCyird7VPXfqPTl6pnZZbWKMGJCNaimG3TxW5ST4I0L/RePkrmpzofL7PDLS
-            4AHkGBQPd+Sf0rnkr0pHk0GbZeF3bOA24EXhIzXgoeLsmw9+4HTl/SLkoxE6M2ne
-            WXB4pzsrIAGRY1LmoyqbgDShjYYElDbgnORJPhQRa06D7bfcyt8aw97n4juO5Cnh
-            iz8A
-            =E1Ri
+            wcFMAxzSiC7ZHNQZARAACg4g710ru5aOFnrsOTnoUqvrdbGVTcfOqn7Pk25RmGyH
+            r6hS/zwdB9rbxGhWSiUFHXIpKFecJ6ste9/MuwdYtyvWC1On7ZtaOb0iGo4Oa8zu
+            EZBtB+yeQYvxfNMef6ibnf4H2IALVccyTJq406QDUSRIoAsrKLI5vKqzyEsrAKbS
+            q8TweMV7L0JySCZa9B+zyof1Y8kMjizu3ldQZiwDc63LhpUuxMkoki+2YIcB0Svx
+            Mm+/emXeLBfyBYjyOMUTStVh+J82Nm6nlCD1TgUgfJUwWKGKNzmRPQaUZCY2HSNf
+            PoW4cpw0xtfNCzQL84xL7Cgz9b+jqeMQcSeTvGS/viZaFgln84ISVQ8nz/64IxS7
+            iRu6uYM92PpIqCZcuLgT3O2yL1e91+amr1UMViGLG4dOFspu8dBpUQYGgqr6wrtq
+            acBfiv8iihXZNLfAooCd1XGFE0b5XZ7C4e10PoAYjNg+cLtbRyh1rHhWPBX55BY8
+            bFLKAJIV49hIZf7KUuaQcXi4+oBM/Gyc0ZzT147iZZdWnJ7NGz7Yn/WB7ITqWrUy
+            OLhRTqEn4hvKnpIlNBzlv0Z3TWhiJhw6tRZYGts3/FLEnFq646oAjbxNxcKlf3xK
+            ASkuJ1uNuFFZLbuTzLSrCOq/H28rBkUFP2xDQQ1eSYdAnkE0MXF+Twda8dSPdQ7S
+            4AHkT7zdy5tUboxpmy9Kbs7E1+GzC+DG4MDhzmPgmOLdijXG4JzlxpCjUfI0icOx
+            BAL7hSieSssfq9NAW9waO0h4RZhznmHgjuQ4n27UVdWR6+iqD/TCQHq14nRsowLh
+            tOYA
+            =0z0k
             -----END PGP MESSAGE-----
         fp: 40B6FAEC80FD467E3FE9421019F6A67BB1B8DDBE
     unencrypted_suffix: _unencrypted
-    version: 3.1.1
+    version: 3.2.0

--- a/example/helm_vars/projectY/sandbox/us-east-1/java-app/secrets.yaml
+++ b/example/helm_vars/projectY/sandbox/us-east-1/java-app/secrets.yaml
@@ -1,30 +1,31 @@
-secret_sandbox_projecty: ENC[AES256_GCM,data:XIHdxCrQY2qphvbcjs9Y,iv:zD/8QS4wEdk43bzBdbnc5ZDTFKwpbSOrFBn6h94INko=,tag:k2in9ny/gpQWU4nOXQ6HzA==,type:str]
+secret_sandbox_projecty: ENC[AES256_GCM,data:DQiceXJvxOnIYupIMGVb,iv:DnzOHPFgHPp/Uaj4mQMTs3INxfnntNWfMUV/5pgmRLE=,tag:sSNyH7Pc1wD9iMj6641glg==,type:str]
 sops:
     kms: []
     gcp_kms: []
-    lastmodified: '2017-11-02T21:33:40Z'
-    mac: ENC[AES256_GCM,data:GXbFlfpc8Es9GN2G590HoRC+AnBD328GXMpsfr4Oewa5EP1Lwo+3kulkxu0NHvNtJtGxnTeutKD0M0V0PrZodzgz9NkFyZDvXICHDiiRiKRUP5WCjBrUxYXKRBgTb9skzjiYXw55xW6o/640hzhGvLI0MGvyAs9C9yFn8nQxi6U=,iv:JJatGw24tVWSGSXZrQ1ADwDAaPfplXpMfriP9FsqXPY=,tag:Lify44u4O5uG8CvTldvBCw==,type:str]
+    azure_kv: []
+    lastmodified: '2018-10-23T19:50:47Z'
+    mac: ENC[AES256_GCM,data:/ZEzpJq6ky+CxtXkqKkRnrLPODsQh4QBlejxPImmwGguI+cEIJZihNecyyqFFOvnmM1nBAqpGna2vl3FhzVGcUOhkjPN8dxFAAK2+y1vs6hW87MXEWYp8p2BQjUV2nfWm8iCt7VN3c9Bx2yLaecOg9chYL0sM92k8GLNwODlGCI=,iv:Ls/dzjtbnflkDSCSt83OmJU1odVxJRKGaAvPvfPcgmE=,tag:1Ooi8+FhjU8Bhyl422WzvQ==,type:str]
     pgp:
-    -   created_at: '2017-11-02T21:33:40Z'
+    -   created_at: '2018-10-23T19:50:47Z'
         enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            wcFMAxzSiC7ZHNQZARAAOg1D4TtuxVGoRkKUVA+i/Xqir3zkDXYxedbMQnXqRQYg
-            2uvaKXJe1srRQY8uNw2T92ne1uaw52RqxTvAvnuuyglJSG+iCLEjNMnF17lnNX7D
-            hV7MQ9KeFpP+TmrnkLXhqgOKxUZDy2AXDvXhLzwVFJ13W/GmGiIc/Kg1Aty85rYX
-            GhB+Dbr3y7Bra0IycuLtNAW0JOvIfHj+U0Ss3ZJKe0aBFmh/bLY+A8xxLgCD7+fy
-            yVzt8G/DeIzGoWfQvq2fK6/koWSW47Q5Q52XbEPCpQnkP5a7ytwfd66wbc+Lpjr1
-            8cAM6xsQJE6LnnMxswM1EPXQ+hSnT95QQigVbRtpK2T/EnY+tLpqq4hn/yt5yVQp
-            fOjpoh+CMGQhoI0hbcwOnqCIJ99XoAC0/ygbovTBdrHI2MVLju7S9sry7O5XFVVG
-            v5nie5iZbyZK+TF3RN3z9rXXEaWwcI/kcrd9YDFlDfNbX14sWuRUSUzZRCZ6LJTH
-            01kmtsmarfPHR2GdWqirTER1za7oSXNsPPPIjcMDDhwdj/AaYWMP/R88w9Vmj9wG
-            FQoOnC0YBvmBrwEqqe2X+/w2savawzGFeXf81MmQHE1YzMipgIqG7QPUBhIAQEx/
-            DRJxRSKZLGKMYGzr1lbFRn9b91xDKAO5jMHW1Oif6KfAOwzhaY8Sg44r7Amghi3S
-            4AHk6GqiC3bIyPFbV7jk/U8vG+EMheAC4Orh4M7gcOJ+CXB34PLlEWZ8dmrkKRE8
-            HvMbYezgrAw4uLKTVeF8uc3iSQYKwEHghOT9lX+kWjAaBTEVOCVorBGc4u1HxS/h
-            Gx0A
-            =Miem
+            wcFMAxzSiC7ZHNQZARAAKI6hbL7Amqr5yQWzo1sOQ4NuPdES+5RzQpR1FTARBd8r
+            B7hWQbFUh5D42B6KiqCM2Vfk/0UYj825jdr2XLVDsMJWYehoMh1Ibbn3Ulb0M56y
+            twJFCLR/4LaN3oWt05ZBnX4C2gQthnDPkBBDcsomEBUYZSW7wjjEHYGpAwjVys6m
+            GjO541Q1/Vz+IVT93YbRiUx2T3OEPnmsz82wPTttZPjG4F7fbjUEqjwJtfswsBHq
+            Q6vflzcikqPJYDoaOc/lnSoalwfSmfn8TECRiU9rivm7HVDIR67OWnQJd9HAwB0W
+            EVWfgzSDD4+n8VGHFTBuQRZJUciZ9BOQ4S4kZyo4immukcmuDqWvTmCky3XplIy9
+            GyMacnm85hEFyQVWvwbmenauvbH9QgxXKr7q1YIzM57fqnRA1wGLsZstOJy1S5Px
+            WoL8mpede0vno0SBdbbJQ3WjNiCnspa10s77I3u5+jCIdV7IySSQIiPhHsSP6iQi
+            xo1Hxl9ugRU3VgDBR1Cq9yCTTohS2ZG6Yk9SzgtIVI+Ab/OKRosecCpwCQ8pJ33l
+            zmGEYZs0EtJJi+DBq2Hy6wSM2NtkmFWiOVQxC3bYDn88yzsMnBXoDro4XRLNZwL0
+            Bu5PFCyird7VPXfqPTl6pnZZbWKMGJCNaimG3TxW5ST4I0L/RePkrmpzofL7PDLS
+            4AHkGBQPd+Sf0rnkr0pHk0GbZeF3bOA24EXhIzXgoeLsmw9+4HTl/SLkoxE6M2ne
+            WXB4pzsrIAGRY1LmoyqbgDShjYYElDbgnORJPhQRa06D7bfcyt8aw97n4juO5Cnh
+            iz8A
+            =E1Ri
             -----END PGP MESSAGE-----
         fp: 40B6FAEC80FD467E3FE9421019F6A67BB1B8DDBE
     unencrypted_suffix: _unencrypted
-    version: 3.0.0
+    version: 3.1.1

--- a/example/helm_vars/secrets.yaml
+++ b/example/helm_vars/secrets.yaml
@@ -1,52 +1,52 @@
-global_secret: ENC[AES256_GCM,data:UxUcuPvk8Ehjzg==,iv:jQClpt2t1OxFfrw6uloFIbZAbc/Pg4+zqxMQvZkDPls=,tag:zPwvY64XPkCtqLKze2jdww==,type:str]
+global_secret: ENC[AES256_GCM,data:tW3e3YO0mffFQQ==,iv:cLs3C0IbhdB1aybbUIZfh8VBFEno32y/YLnJwhEq/iE=,tag:4F6PsxCj2Oxn0t49W7xfTQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
-    lastmodified: '2018-10-23T19:56:48Z'
-    mac: ENC[AES256_GCM,data:G3CDvgIIfGc9vE2Mz/Jr8lSoxjq2eqNgBmytGKP+R5/HZZGYuJFOLBm0hRmPWXxe88thPyXFArklvEjhPobyvYrYN93dph3O4SaoZvKeuv4DgNy9SZaI3jfXQGYEpsNQajJGulwL73STQBzw6sT/aG6uLzNEbIrgxb8VyahrAUI=,iv:ieDrjPaV6Nr5SY7TPPhlpKKzfxokDMz+SPU6TraZ7Vk=,tag:c2ObhWTIdSWr2VjG0CAOiw==,type:str]
+    lastmodified: '2019-03-29T11:02:06Z'
+    mac: ENC[AES256_GCM,data:rDHF8C+s0WRHxsy6JKffkpwasJDp55fAxDY5WOXtz4u44bLNw/SrMDCBsYzQ1UcwxYMY+CAQINyeFyqeH5GjDPW6sJ1pmEQk0QTV8NdD/O/dDfHsXfTyFY8ZBNoIJJe8s3uMq3vm3L6BLjRJ8jHtbXwF/c3HOFYzKC+1J0X9TmE=,iv:ydQoImoP2Jt/tvOecurX7XsEIKtAGRJ6YzI1+MsMsuQ=,tag:gB8pvoRev9iProFjEga7vQ==,type:str]
     pgp:
-    -   created_at: '2018-10-23T19:56:47Z'
+    -   created_at: '2019-03-29T11:02:06Z'
         enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            wcFMAxYpv4YXKfBAARAAoPFZY1Vrq7hABGE5NeFuezVOBJ2g31fdFkHKK792nU5D
-            k5IbInF11afAUdbxCEhX0cRN5OodoKC3v7fjUQfFBiDqC2qf4CczhWbvY605mfcD
-            4cX8dswD5kLx7RvaReE71IkmKTtvEwCRIs3nhVp0A5p1cSk0TRa9e8pLrcHUoa/i
-            QNQDAo76DChv4UJD9ix8GK34Wrm7SBmCcEzjpNgAKsl+RlpM6G0E12rjUaxnmCqz
-            Md4Gpqcx3rZhkJZWdiUufwTocM8zVKEPSNbloWBQbsZ1pFdO2OlZhP8ozpwfAana
-            eDEjjo4tX3MytyUonocpezCiyapWbexL0nl2yxsfHvCIwAzT8OwSxpNv1EI0AgwZ
-            dRWmvqVOjP6lAvJPm7yX8YZQQ2oDdHNABwDBXBgA+TCCUZGEk0sZhs5SRYGByPlO
-            2x83opqI7eJcbYMjaf4q+os7fEdPcgWPokOZ+ocfLmKQJ5JG5vHVXd+fF8jh9tTo
-            3xYjWx5AFkpW9Piqo9Hap9zjvo9xCXqnjMfp5AapMpJj6E6euB7UVTYivKRH5fUu
-            c4niT57NRkbudzcc1EliV7ih7g3h0N5B2i+RQaAsUo6GqH34a4MJU5GaTJpg5Y6O
-            25eMHLV9XstXMnx2mQV4d7EoqWmpwPjuIEsQqG20mIsQe9TiqjUunXzAUQgw/l7S
-            4AHkvZcs0xPp0AaOq55hTHl57OE+jeDT4Ivh1bbg3OKa8Q5Y4MzlVOgz/ct1qXmt
-            D6srwoLz8m2MpHptbo86CnJw+kcya1rgyeSalFFqjSrf/gOAvVZ54NUZ4iGaXpnh
-            I7wA
-            =814a
+            wcFMAxYpv4YXKfBAARAAkm4oBJlVN/yMSJasC/dYJvrCAooV2P6Oljsiw+VaKzRI
+            fNP7guPGXm7HMMjgF4e9RrBH4XsVLVSEL1yjXsP4s1CoiLOMqti/MvkPDvKjLzxT
+            ATvzpD7nAs0YEnQNlf7/DHm9JAGPWjfI2UJ/oEp4ba+bMIVg4nPV47n06f31m5Ur
+            hYMxUoFdCQbxCOnMCvcbTR9UMPfWLdd0Rr4T2NUSAY8Tr1LTM+iXRTdeJKy1AAhr
+            t/mu7sDADEm9aJSIbbE8nYSIzZuN7yL02CuZZci3HGOUV71cLVeOHC8MvKx2rwf8
+            iT7L0dHwmi9mdfmIyNwKRhvzSR6RllUhfuDXB4cQ54/xnQ/7vF+YNdbJa8xl9Va/
+            G60XClMsTr3iGOWU4Q2wlM+f7RGF6Bfwek5R0vWxGc/GshB4kQAu37g/L2E/79JX
+            m8LtZJl89p1n550lioX/+pituY8zd9uTsiqn21OIT5Uk830OygBcJTQepkz5lLI5
+            c6OsuODNEvw2CJ6eHxAfG6GdW+B2spDJcJyELaKbP9zxDEK9RRC8MDxILDoOsk4I
+            ITKbx8jgeUXH6S7fRAvRDbzCLgMjKEUuEDmYO4a7d4m4Jf4htvATtmS8JPPpv5jQ
+            1exXORaScAnmkFT0haupgBAX7dsCx36xpqqPFneFgTCzH3HUVhf7IpBG+opUhFTS
+            4AHkVg6v8c/fqNfd41cKSERhG+GrLODV4PXhmzbgQuJpTjIx4HXlUXDFGDg2akB8
+            UjWODkgtSitXvY6t3koS6d1BLH2L5rTg1+Qv4s9R4rBbMsB5Ahw6v/+b4q55Ubnh
+            DrIA
+            =U903
             -----END PGP MESSAGE-----
         fp: 4434EA5D05F10F59D0DF7399AF1D073646ED4927
-    -   created_at: '2018-10-23T19:56:47Z'
+    -   created_at: '2019-03-29T11:02:06Z'
         enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            wcFMAxzSiC7ZHNQZARAAFtOmwPF0DCcJGUQsRD4bb8dMyomAbRcg0+n39NQSQQuy
-            knXvPcGw4+jo/rROedL669dBgROyA/GI+fKbnG/9fz1LsZxTTr44vQ65BixAVsuY
-            S7lVeR+Mdq0UHpHlm+tgzjVw4pzdcmfnQQJ45QwUGD5SKqABu+pcGiHlzNu4viG8
-            zsQo6umXsTGO32GqM2E/E7+s3SqbU/gJrB8UeLBr1vP1DNTHi94ZNFi4tF3GnQsg
-            2uwGJNF+WOwctwVaAWcbYdwuBdLtkmjCqXZqZe2MOgzKv8+D8UFGaVkGzScAcOeL
-            HbKBPBVUnZvWb+ExakSEmiOiLM1D4aJUfOhX+90ETQyESIbII7lUA5OzUxLIk8cM
-            vrihEkD25Gpv8UVIJHjbYFg7aRLdNt+52SsKdSmy92268fwsRBFNTQCeIlvihnTa
-            QujoB7eew+b9Zq5Iag4VhwfD2AzID9T5x6vfZL4qi9plXbhpWGG+7Pf/9NaYnoYJ
-            J9hfNmsR/4zx0D3Xp2nJPPemVmikMiIYlslQ0V1/fVS14/e6sTlg6hjkQQuk68oH
-            h1Es+0bul9NxXo30K7y6Q3ioCUVDdXCcGQ2zzh7G96beWfZHxi3gBeu3filmoaok
-            E0iu3vQIq3fb3T03xerrz2d2CjgdwY4rmCnJ8Ny0N/0B5Xo9LTX+UesrnO4WusnS
-            4AHkzsOOWsX2zoP9uY4cdx6XBeGCZOCj4NzhOXbg8eKqR+OP4NLly2T8AhthlqbQ
-            N1FnRbsYmATr2NppvT9djuhILmL0uELgr+SnxPpwQI4x2Jhh1p9J7p2J4gXf4Dnh
-            FTUA
-            =l0Z2
+            wcFMAxzSiC7ZHNQZARAAb699zXK7tDKBJXQRHkSWN5/plCP1S+VouTkxKYpB1uYU
+            ivNyDAbYfXnU7LMClcK+qVdpK1JPULGjxJLVQLRsg1HRwYvkY/zKkXMUz824X2Hu
+            MeXywxzsS0pwLJ4PutmTrRWRSEltxed4vgndrzxkJtw7Fxf2eh8lJcevsZGXQyW/
+            2fghXVhGnQZe/MaynPcmI8F3Wxxa+6r1WnlSL3fvICQtyAAzS8rmDM7n8Iwzh4j7
+            +zaBQ3wavYFX7lILa4JilwAku3VxZBgUh7FDxy62lZEE1giGJykW9DQaCMCdJiJh
+            5gG+yMIcjol2EQC+em//ZGcPHOR+qaG6HXUWhVFo67Gg3dKoYPXqjTFrAjg/ujja
+            utx6gxXUcOFyPFlJw7orG+P08PgshRVYT4Go3UAbSR/tjvcmyrKMRQBvF+Y1jRbb
+            y6GgCWae2lAO3wPejvFYn2yAnl9TRIZWAqet/1BJvnls+QmMCLkhLBx9l8zIA/iE
+            G2vO/R5vwC9j07UNLGSjrVvadnw51UT8efEiQOPRRhMSRe3tbq6g/2tkaRAt8PTP
+            J9SzM5BcPiGBHlrjAvJkDzmmXorEK317XZ3hPMY1326Rn37ZMenfYmCsv2Y+KN66
+            5h3tzSF2+8CeMowRjygFh5AQm0jpmHGNQkcDUfL7ewr9v/lrKJt6eGK5WnUM8VXS
+            4AHkxq+E5sc6FrwYQYc5x28W/+F82+Az4O7hlATgb+LOrE4g4D7liQNTKREiREJQ
+            N84cvTNEp7NIHr7+tJRYuNjfAO+4743gb+Rfuqf6pXHSw7R0kYE70tid4tovsGDh
+            VqIA
+            =FY1e
             -----END PGP MESSAGE-----
         fp: 40B6FAEC80FD467E3FE9421019F6A67BB1B8DDBE
     unencrypted_suffix: _unencrypted
-    version: 3.1.1
+    version: 3.2.0

--- a/example/helm_vars/secrets.yaml
+++ b/example/helm_vars/secrets.yaml
@@ -1,51 +1,52 @@
-global_secret: ENC[AES256_GCM,data:SNnd020i6xPnww==,iv:HEoQccGX9TKsBARE0UOPq3bEENQeail/NREzTY5We9s=,tag:BJi2NuKCOmsgy6Di+SMfgg==,type:str]
+global_secret: ENC[AES256_GCM,data:UxUcuPvk8Ehjzg==,iv:jQClpt2t1OxFfrw6uloFIbZAbc/Pg4+zqxMQvZkDPls=,tag:zPwvY64XPkCtqLKze2jdww==,type:str]
 sops:
     kms: []
     gcp_kms: []
-    lastmodified: '2017-11-02T21:33:42Z'
-    mac: ENC[AES256_GCM,data:VymC82E5SP0heF6IuG60BkZKg0CGZyLXaFkqZWNj7msYH1+vhVTJHt6Y2AdvcFNcazbEW5qUmn19aMm8YVb0Ph6ZLOhS8j+U9ClWe1PPaq7JiePDMaLFDCdrvLNPwE5rDFR2jeT7NxHxquUKoJDzZVPDakE0B9qzkcQRPaQQGYI=,iv:P3hy+OeIUeD4/dTmweZWhC9wLILPQutqGO+e7mpmyeI=,tag:A3fd/elRnZMbKh4t5hsShg==,type:str]
+    azure_kv: []
+    lastmodified: '2018-10-23T19:56:48Z'
+    mac: ENC[AES256_GCM,data:G3CDvgIIfGc9vE2Mz/Jr8lSoxjq2eqNgBmytGKP+R5/HZZGYuJFOLBm0hRmPWXxe88thPyXFArklvEjhPobyvYrYN93dph3O4SaoZvKeuv4DgNy9SZaI3jfXQGYEpsNQajJGulwL73STQBzw6sT/aG6uLzNEbIrgxb8VyahrAUI=,iv:ieDrjPaV6Nr5SY7TPPhlpKKzfxokDMz+SPU6TraZ7Vk=,tag:c2ObhWTIdSWr2VjG0CAOiw==,type:str]
     pgp:
-    -   created_at: '2017-11-02T21:33:41Z'
+    -   created_at: '2018-10-23T19:56:47Z'
         enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            wcFMAxYpv4YXKfBAARAARZzY0Jaz8w2lTUuaMTE0ZqF1Q1ewjlyKt9DtefeO+JHc
-            gX7LUtcFKI6D/cGS3rYQFdM4k5d2hj9F+LJlp8uQJLY0nFcpOHemWzi0/7HfaZX2
-            vJtBIggkQi7p1IBRqTV/+uuZJ5QUeiqw1JmB+ieaAJXyvYHVVS0jjq3LwDWq2fcO
-            r+rv14FH7EDYKpSwD9EbgoS6fZHn8MO4LqTZet5XyEI3N11CztxxKDqxhH5u6npA
-            poh6ATksaBkBdELcuYLGYt4urc5buDa+1DgpCuyAIOW245p+i5y2pD6Dfqazp+5j
-            nAnEwyNvBxv+GC5+9FJSd0K6NqbTpx//PCpkHMwqsVSFwhMo0UGP3JJUnYVycN2u
-            ZRFUpof3lSi1dj0Bi4AyQfzqBNskSUqLHSgBoZcuDNHAP8Y+okkg4Y7ettmTD4Gr
-            AIt006bd7+ZzSSJraXCoEgjMipydW62cm0RxmlXapE3ENDKABM3Er1HWgp8+ntrv
-            alYeXcq0o6Kf/cZgo7/GqAUT4j6yl1iEnlczn1GNIPRQIocOX4kPpvaznKJkgHsB
-            OIr7RjRyLgMPak5p/4B1NESy116VJfEJD15l5OX9Q1H9MlTT1pJgdwpKtue0PjdZ
-            f3oz99MBdls2fZd1LB5VYGs5PB6OHPl214E4ZQ7MgT+OW9FDIstHdBXSUCM75/bS
-            4AHkNhYeR1mNtFS6aTwEr1Knx+E6veBo4Mbhe5rg/+Iw2IW64NXlMAyikizGyjwL
-            N5PojqVpvt+5SyWb6wqmNTU1ucCs0gngkeQGAD5QtVJbIypuA28ufEEL4utk0Yzh
-            EAoA
-            =ykPW
+            wcFMAxYpv4YXKfBAARAAoPFZY1Vrq7hABGE5NeFuezVOBJ2g31fdFkHKK792nU5D
+            k5IbInF11afAUdbxCEhX0cRN5OodoKC3v7fjUQfFBiDqC2qf4CczhWbvY605mfcD
+            4cX8dswD5kLx7RvaReE71IkmKTtvEwCRIs3nhVp0A5p1cSk0TRa9e8pLrcHUoa/i
+            QNQDAo76DChv4UJD9ix8GK34Wrm7SBmCcEzjpNgAKsl+RlpM6G0E12rjUaxnmCqz
+            Md4Gpqcx3rZhkJZWdiUufwTocM8zVKEPSNbloWBQbsZ1pFdO2OlZhP8ozpwfAana
+            eDEjjo4tX3MytyUonocpezCiyapWbexL0nl2yxsfHvCIwAzT8OwSxpNv1EI0AgwZ
+            dRWmvqVOjP6lAvJPm7yX8YZQQ2oDdHNABwDBXBgA+TCCUZGEk0sZhs5SRYGByPlO
+            2x83opqI7eJcbYMjaf4q+os7fEdPcgWPokOZ+ocfLmKQJ5JG5vHVXd+fF8jh9tTo
+            3xYjWx5AFkpW9Piqo9Hap9zjvo9xCXqnjMfp5AapMpJj6E6euB7UVTYivKRH5fUu
+            c4niT57NRkbudzcc1EliV7ih7g3h0N5B2i+RQaAsUo6GqH34a4MJU5GaTJpg5Y6O
+            25eMHLV9XstXMnx2mQV4d7EoqWmpwPjuIEsQqG20mIsQe9TiqjUunXzAUQgw/l7S
+            4AHkvZcs0xPp0AaOq55hTHl57OE+jeDT4Ivh1bbg3OKa8Q5Y4MzlVOgz/ct1qXmt
+            D6srwoLz8m2MpHptbo86CnJw+kcya1rgyeSalFFqjSrf/gOAvVZ54NUZ4iGaXpnh
+            I7wA
+            =814a
             -----END PGP MESSAGE-----
         fp: 4434EA5D05F10F59D0DF7399AF1D073646ED4927
-    -   created_at: '2017-11-02T21:33:41Z'
+    -   created_at: '2018-10-23T19:56:47Z'
         enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            wcFMAxzSiC7ZHNQZARAAJcYeCBjZoYGiPlzEjmqenK3wo1AuGgWHbAX9z9tcVa0w
-            r3jRyXohRtkwXa0xgGwI1YUScXqKGLr1dDqT3wKgW0OoOQ17Tx2Km5nkomBzJX4l
-            +8s5Vgmqn4k9GkVBDoufYnIjKx/0+yImH364P3DMQ3M2HbADVokSGOI/lJizMVMJ
-            HZDKAFsHQ2OH+TbWY+9uPeJjVQdzqNssUf1n8wkf9opbYey4+SUmgC8IA+JGCASO
-            RonSj7x39/fBi1wpqZMkZBq0XISmvGfqLovS1FdyQ5Yl9jPKjU6mWqyl32aLOQe4
-            OBMNeLHYZ+fkdEuAi8YVqqsYrMGET6cBWRtiuzSIsMDnw3selqRmC4/awGOjbWvG
-            hGAkLdClT7helRSvYyov1lyMGVwy1+W0FoulaqoSZD+hRXCH+QvrchFgCY4oDUCa
-            BXm7G9Zbk3/6DBi4+rxlEO1y/R0nPjO/XfUZpMP7f3Hog9Eg7CC7hyyWsi4mgS93
-            2IZqtfs0EMSh7nxnIpgg80+e1iNPPkF5BBkNYuesVh7LOGweXKrLjQSJgfu5l6wr
-            dRKoB1IkT74pfZYrEkist647+XeNjjZ0PhRioRxbrWtD1cFVlS4nO6gcQ8EynEsX
-            jToYzYuCORnEQNNOF3wRbrsYMtisCt+MTtbP3V53YG2CBxpmGq4+DAfLwIOGkVLS
-            4AHk2sPNtwYWAIW2vYc7i2HfHeElmOCb4AbhE7HgPuJ4bqRD4K3l+x7Ksz8a833k
-            J8gZrgGLiS4Qg+TgPwUmJBA9vJj4a/zgmOToHGCuCi1/Ay6IdB5XV4yt4hull0Dh
-            E5kA
-            =JFP/
+            wcFMAxzSiC7ZHNQZARAAFtOmwPF0DCcJGUQsRD4bb8dMyomAbRcg0+n39NQSQQuy
+            knXvPcGw4+jo/rROedL669dBgROyA/GI+fKbnG/9fz1LsZxTTr44vQ65BixAVsuY
+            S7lVeR+Mdq0UHpHlm+tgzjVw4pzdcmfnQQJ45QwUGD5SKqABu+pcGiHlzNu4viG8
+            zsQo6umXsTGO32GqM2E/E7+s3SqbU/gJrB8UeLBr1vP1DNTHi94ZNFi4tF3GnQsg
+            2uwGJNF+WOwctwVaAWcbYdwuBdLtkmjCqXZqZe2MOgzKv8+D8UFGaVkGzScAcOeL
+            HbKBPBVUnZvWb+ExakSEmiOiLM1D4aJUfOhX+90ETQyESIbII7lUA5OzUxLIk8cM
+            vrihEkD25Gpv8UVIJHjbYFg7aRLdNt+52SsKdSmy92268fwsRBFNTQCeIlvihnTa
+            QujoB7eew+b9Zq5Iag4VhwfD2AzID9T5x6vfZL4qi9plXbhpWGG+7Pf/9NaYnoYJ
+            J9hfNmsR/4zx0D3Xp2nJPPemVmikMiIYlslQ0V1/fVS14/e6sTlg6hjkQQuk68oH
+            h1Es+0bul9NxXo30K7y6Q3ioCUVDdXCcGQ2zzh7G96beWfZHxi3gBeu3filmoaok
+            E0iu3vQIq3fb3T03xerrz2d2CjgdwY4rmCnJ8Ny0N/0B5Xo9LTX+UesrnO4WusnS
+            4AHkzsOOWsX2zoP9uY4cdx6XBeGCZOCj4NzhOXbg8eKqR+OP4NLly2T8AhthlqbQ
+            N1FnRbsYmATr2NppvT9djuhILmL0uELgr+SnxPpwQI4x2Jhh1p9J7p2J4gXf4Dnh
+            FTUA
+            =l0Z2
             -----END PGP MESSAGE-----
         fp: 40B6FAEC80FD467E3FE9421019F6A67BB1B8DDBE
     unencrypted_suffix: _unencrypted
-    version: 3.0.0
+    version: 3.1.1


### PR DESCRIPTION
When examples were encrypted with older 3.0.0 SOPS version, tests would fail when more recent SOPS version was used.