### PR TITLE
Added suport for `-f=`

### DIFF
--- a/secrets.sh
+++ b/secrets.sh
@@ -436,6 +436,10 @@ EOF
             -f|--values)
 		cmdopts+=("$1")
 		yml="$2"
+		# increase support for -f=myfile.yaml or -f=myfile (helm support both spaces and equal sign)
+		if [[ $yml =~ ^=.*$ ]]; then
+		    yml="${yml/=/}"
+		fi
 		if [[ $yml =~ ^(.*/)?secrets(\.[^.]+)*\.yaml$ ]]
 		then
 		    decrypt_helper $yml ymldec decrypted


### PR DESCRIPTION
The wrapper should support `-f=` as well as `-f` when wrapping the helm commands. This falls in line
with what helm supports as commands. This addition supports rewriting and value found in -f to remove
a preceding `=` sign, if one should exist.