### PR TITLE
Fix template command to not print list of deleted files

### DIFF
--- a/secrets.sh
+++ b/secrets.sh
@@ -460,7 +460,9 @@ EOF
     ${HELM_BIN} ${TILLER_HOST:+--host "$TILLER_HOST" }"$cmd" $subcmd "$@" "${cmdopts[@]}"
     helm_exit_code=$?
     # cleanup on-the-fly decrypted files
-    [[ ${#decfiles[@]} -gt 0 ]] && rm -v "${decfiles[@]}"
+    local rmflags=(-v)
+    if [ "$cmd" == "template" ]; then rmflags=(); fi
+    [[ ${#decfiles[@]} -gt 0 ]] && rm "${rmflags[@]}" "${decfiles[@]}"
 }
 
 helm_command() {


### PR DESCRIPTION
For all wrapped Helm commands the list of decrypted files is printed as they get removed at the end of plugin execution. For the `template` command this is undesired, as it means you cannot simply run `helm secrets template` and get valid YAML output.

This change suppresses the output of deleted files for the `template` command only, meaning it does not alter the behavior of other commands, but just fixes the `template` command to work as I imagine most people would expect it to work.

Fixes issues #126 and #132.