### PR TITLE
Removing verbose deletion as it breaks helm template functions.

### DIFF
--- a/secrets.sh
+++ b/secrets.sh
@@ -372,7 +372,7 @@ clean() {
 	return
     fi
     local basedir="$1"
-    find "$basedir" -type f -name "secrets*${DEC_SUFFIX}" -exec rm -v {} \;
+    find "$basedir" -type f -name "secrets*${DEC_SUFFIX}" -exec rm  {} \;
 }
 
 helm_wrapper() {
@@ -460,7 +460,7 @@ EOF
     ${HELM_BIN} ${TILLER_HOST:+--host "$TILLER_HOST" }"$cmd" $subcmd "$@" "${cmdopts[@]}"
     helm_exit_code=$?
     # cleanup on-the-fly decrypted files
-    [[ ${#decfiles[@]} -gt 0 ]] && rm -v "${decfiles[@]}"
+    [[ ${#decfiles[@]} -gt 0 ]] && rm  "${decfiles[@]}"
 }
 
 helm_command() {


### PR DESCRIPTION
Remove the verbose flags as it breaks anyone trying to use helm secrets template as input to another process, such as argocd.