### PR TITLE
Support for Windows via bash.exe

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -3,6 +3,9 @@ version: "2.0.2"
 usage: "Secrets encryption in Helm for Git storing"
 description: |-
   This plugin provides secrets values encryption for Helm charts secure storing
+platformCommand:
+  - os: windows
+    command: bash.exe $HELM_PLUGIN_DIR/secrets.sh
 command: "$HELM_PLUGIN_DIR/secrets.sh"
 useTunnel: true
 hooks:

--- a/secrets.sh
+++ b/secrets.sh
@@ -438,7 +438,7 @@ EOF
 		if [[ $yml =~ ^=.*$ ]]; then
 		    yml="${yml/=/}"
 		fi
-		if [[ $yml =~ ^(.*/)?secrets(\.[^.]+)*\.yaml$ ]]
+		if [[ $yml =~ ^(.*[/\\])?secrets(\.[^.]+)*\.yaml$ ]]
 		then
 		    decrypt_helper $yml ymldec decrypted
 		    cmdopts+=("$ymldec")


### PR DESCRIPTION
This PR adds support for helm-secrets on Windows. It works by using `bash.exe`, a Windows port of the bash shell that most developers will have as it is bundled with Git for Windows (the official distribution).

The user also needs to install gnupg and sops, both of which can be installed via Chocolatey https://chocolatey.org/

```
PS > helm secrets dec .\helm_vars\secrets.dev.yaml
Decrypting .\helm_vars\secrets.dev.yaml
```

I've tested the enc, dec, view and edit commands, and the install wrapper, and they all work as expected from a powershell prompt.

I had to modify the regex used in the wrapper to recognise paths in Windows, which can use \ instead of / for directories.

If this PR is accepted I'd be happy to add some documentation to the README on installation.
